### PR TITLE
fix(configuration)

### DIFF
--- a/base/Annium/src/Annium.Analyzers/AnalyzerHelpers.cs
+++ b/base/Annium/src/Annium.Analyzers/AnalyzerHelpers.cs
@@ -105,5 +105,6 @@ internal static class AnalyzerHelpers
     /// <param name="compilation">The compilation to resolve against.</param>
     /// <returns>The resolved <c>System.Exception</c> symbol, or <see langword="null"/> when it can't be found.</returns>
     internal static INamedTypeSymbol? ResolveExceptionType(Compilation compilation) =>
+        // FullName is non-null for the concrete Exception type (only open generics / arrays return null).
         compilation.GetTypeByMetadataName(typeof(Exception).FullName!);
 }

--- a/base/Annium/src/Annium.Testing/Collection/DictionaryExtensions.cs
+++ b/base/Annium/src/Annium.Testing/Collection/DictionaryExtensions.cs
@@ -89,6 +89,7 @@ public static class DictionaryExtensions
         where TKey : notnull
     {
         CheckCount(value, value?.Count ?? 0, count, message, valueEx, countEx);
+        // The Check* helper above throws ArgumentNullException when value is null, so value is non-null here.
         return value!;
     }
 
@@ -115,6 +116,7 @@ public static class DictionaryExtensions
         where TKey : notnull
     {
         CheckCount(value, value?.Count ?? 0, count, message, valueEx, countEx);
+        // The Check* helper above throws ArgumentNullException when value is null, so value is non-null here.
         return value!;
     }
 
@@ -137,6 +139,7 @@ public static class DictionaryExtensions
         where TKey : notnull
     {
         CheckEmpty(value, value?.Count ?? 0, message, valueEx);
+        // The Check* helper above throws ArgumentNullException when value is null, so value is non-null here.
         return value!;
     }
 
@@ -159,6 +162,7 @@ public static class DictionaryExtensions
         where TKey : notnull
     {
         CheckEmpty(value, value?.Count ?? 0, message, valueEx);
+        // The Check* helper above throws ArgumentNullException when value is null, so value is non-null here.
         return value!;
     }
 
@@ -181,6 +185,7 @@ public static class DictionaryExtensions
         where TKey : notnull
     {
         CheckNotEmpty(value, value?.Count ?? 0, message, valueEx);
+        // The Check* helper above throws ArgumentNullException when value is null, so value is non-null here.
         return value!;
     }
 
@@ -203,6 +208,7 @@ public static class DictionaryExtensions
         where TKey : notnull
     {
         CheckNotEmpty(value, value?.Count ?? 0, message, valueEx);
+        // The Check* helper above throws ArgumentNullException when value is null, so value is non-null here.
         return value!;
     }
 

--- a/base/Annium/src/Annium.Testing/TypeExtensions.cs
+++ b/base/Annium/src/Annium.Testing/TypeExtensions.cs
@@ -24,6 +24,7 @@ public static class TypeExtensions
     {
         (value is T).IsTrue(message ?? $"{valueEx} is {value?.GetType()}, not {typeof(T)}");
 
+        // The assertion above throws when value is null or not T, so value is non-null here.
         return (T)value!;
     }
 
@@ -44,6 +45,7 @@ public static class TypeExtensions
     {
         (value?.GetType() == typeof(T)).IsTrue(message ?? $"{valueEx} is {value?.GetType()}, not {typeof(T)}");
 
+        // The assertion above throws when value is null or not T, so value is non-null here.
         return (T)value!;
     }
 }

--- a/base/Annium/src/Annium/Collections/Generic/DoubleEdgeQueue.cs
+++ b/base/Annium/src/Annium/Collections/Generic/DoubleEdgeQueue.cs
@@ -26,13 +26,20 @@ public sealed class DoubleEdgeQueue<T> : IDoubleEdgeQueue<T>
     /// </summary>
     /// <exception cref="InvalidOperationException">Thrown if the queue is empty.</exception>
     public T First =>
-        _entries.Count > 0 ? _entries.First!.Value : throw new InvalidOperationException("queue is empty");
+        // First is non-null when Count > 0 (LinkedList invariant).
+        _entries.Count > 0
+            ? _entries.First!.Value
+            : throw new InvalidOperationException("queue is empty");
 
     /// <summary>
     /// Gets the last element in the queue.
     /// </summary>
     /// <exception cref="InvalidOperationException">Thrown if the queue is empty.</exception>
-    public T Last => _entries.Count > 0 ? _entries.Last!.Value : throw new InvalidOperationException("queue is empty");
+    public T Last =>
+        // Last is non-null when Count > 0 (LinkedList invariant).
+        _entries.Count > 0
+            ? _entries.Last!.Value
+            : throw new InvalidOperationException("queue is empty");
 
     /// <summary>
     /// The underlying linked list storing the elements.

--- a/base/Annium/src/Annium/EnumExtensions.cs
+++ b/base/Annium/src/Annium/EnumExtensions.cs
@@ -167,6 +167,7 @@ public static class EnumExtensions
 
         foreach (var item in type.GetFields().Where(x => x.IsStatic))
         {
+            // GetValue(null) returns the static enum field's value (non-null); ToString() on the converted primitive is non-null.
             var value = (ValueType)item.GetValue(null)!;
 
             result.Add(item.Name.ToLowerInvariant(), value);
@@ -226,9 +227,11 @@ public static class EnumExtensions
         // if not flags - simply add all values
         if (type.GetCustomAttribute<FlagsAttribute>() is null)
             foreach (var item in type.GetFields().Where(x => x.IsStatic))
+                // GetValue(null) returns the static enum field's value, which is non-null.
                 result.Add((ValueType)Convert.ChangeType(item.GetValue(null)!, valueType));
         else
         {
+            // GetValue(null) returns each static enum field's value, which is non-null.
             var values = type.GetFields()
                 .Where(x => x.IsStatic)
                 .Select(x => (long)Convert.ChangeType(x.GetValue(null)!, typeof(long)))

--- a/base/Annium/src/Annium/Internal/Collections/Generic/ExpiringStore.cs
+++ b/base/Annium/src/Annium/Internal/Collections/Generic/ExpiringStore.cs
@@ -49,7 +49,9 @@ internal sealed class ExpiringStore<TKey, TValue> : IDisposable, IAsyncDisposabl
     {
         _timeProvider = timeProvider;
         _evictionTimer = new Timer(
-            static state => ((ExpiringStore<TKey, TValue>)state!).Evict(),
+            // state is the `this` reference passed as the next argument, so the cast target is non-null.
+            static state =>
+                ((ExpiringStore<TKey, TValue>)state!).Evict(),
             this,
             evictionInterval,
             evictionInterval

--- a/base/Annium/src/Annium/Internal/TrackingWeakReferenceOfT.cs
+++ b/base/Annium/src/Annium/Internal/TrackingWeakReferenceOfT.cs
@@ -45,7 +45,9 @@ internal sealed class TrackingWeakReference<T> : ITrackingWeakReference<T>
     /// </summary>
     /// <param name="target">When this method returns, contains the referenced object if it is still alive; otherwise, null.</param>
     /// <returns>true if the referenced object is still alive; otherwise, false.</returns>
-    public bool TryGetTarget(out T target) => _ref.TryGetTarget(out target!);
+    public bool TryGetTarget(out T target) =>
+        // out target! mirrors WeakReference<T>.TryGetTarget's [MaybeNullWhen(false)] contract: target is set when returning true.
+        _ref.TryGetTarget(out target!);
 
     /// <summary>
     /// Finalizes the instance and raises the <see cref="OnCollected"/> event off the finalizer thread.

--- a/base/Annium/src/Annium/Reflection/Types/GetInheritanceChainExtension.cs
+++ b/base/Annium/src/Annium/Reflection/Types/GetInheritanceChainExtension.cs
@@ -40,6 +40,8 @@ public static class GetInheritanceChainExtension
             if (type.BaseType is not null)
                 while (type.BaseType != typeof(object))
                 {
+                    // BaseType is non-null in this loop: entered only when type.BaseType is not null,
+                    // and the loop runs while BaseType != object.
                     chain.Add(type.BaseType!);
                     type = type.BaseType!;
                 }

--- a/base/Annium/src/Annium/Reflection/Types/GetTargetImplementationExtension.cs
+++ b/base/Annium/src/Annium/Reflection/Types/GetTargetImplementationExtension.cs
@@ -176,6 +176,8 @@ public static class GetTargetImplementationExtension
             if (!type.IsArray)
                 return null;
 
+            // Both types are arrays here (target.IsArray checked above, type.IsArray enforced by the early return),
+            // so GetElementType() is non-null.
             var elementImplementation = type.GetElementType()!
                 .GetTargetImplementation(target.GetElementType()!, genericParameters);
 
@@ -389,6 +391,7 @@ public static class GetTargetImplementationExtension
                 return null;
         }
 
+        // The loop above returns null on any null arg, so args has no null elements here.
         if (!target.GetGenericTypeDefinition().TryMakeGenericType(out var result, args!))
             return null;
 

--- a/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Class.cs
+++ b/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Class.cs
@@ -111,13 +111,17 @@ file class ClassHelper
     public static Type[]? ResolveBase(Type type, Type target)
     {
         var unboundBaseType = type.GetUnboundBaseType();
+        // ResolveBase runs only after callers verify type.BaseType is non-null (ResolveClassArgumentsBy* guards),
+        // so resolving the present base yields a non-null unbound type.
         var baseArgs = unboundBaseType!.ResolveGenericArgumentsByImplementation(target);
         if (baseArgs is null)
             return null;
 
+        // type.BaseType is non-null per the same caller guards.
         if (!type.BaseType!.GetGenericTypeDefinition().TryMakeGenericType(out var baseImplementation, baseArgs))
             return null;
 
+        // TryMakeGenericType returned true above, so baseImplementation was set.
         return type.ResolveGenericArgumentsByImplementation(baseImplementation!);
     }
 }

--- a/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Helpers.cs
+++ b/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Helpers.cs
@@ -69,6 +69,7 @@ public static partial class ResolveGenericArgumentsByImplementationExtension
         target = implementation;
         (Type[]? sourceArgs, Type[]? targetArgs) = target switch
         {
+            // GetElementType() is non-null for array types; this arm runs only when IsArray is true.
             { IsArray: true } => (new[] { source.GetElementType()! }, new[] { target.GetElementType()! }),
             { IsGenericType: true } => (source.GetGenericArguments(), target.GetGenericArguments()),
             _ => (null, null),

--- a/base/Annium/src/Annium/Threading/Channels/ChannelReaderExtensions.cs
+++ b/base/Annium/src/Annium/Threading/Channels/ChannelReaderExtensions.cs
@@ -13,13 +13,6 @@ namespace Annium.Threading.Channels;
 public static class ChannelReaderExtensions
 {
     /// <summary>
-    /// Default poll cadence in milliseconds for <see cref="WhenEmptyAsync{T}"/>. Matches the
-    /// same default used by <c>Wait</c> and <c>Expect</c> so behaviour stays consistent across the
-    /// area's polling primitives.
-    /// </summary>
-    private const int DefaultDelayMs = 25;
-
-    /// <summary>
     /// Reads an item from the channel reader.
     /// </summary>
     /// <typeparam name="T">The type of items in the channel.</typeparam>
@@ -97,7 +90,7 @@ public static class ChannelReaderExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static async Task WhenEmptyAsync<T>(
         this ChannelReader<T> reader,
-        int delay = DefaultDelayMs,
+        int delay = PollingDefaults.PollDelayMs,
         CancellationToken ct = default
     )
     {

--- a/base/Annium/src/Annium/Threading/PollingDefaults.cs
+++ b/base/Annium/src/Annium/Threading/PollingDefaults.cs
@@ -1,0 +1,13 @@
+namespace Annium.Threading;
+
+/// <summary>
+/// Shared default poll cadence for the area's polling primitives (<see cref="Tasks.Wait"/> and
+/// <see cref="Channels.ChannelReaderExtensions"/>), keeping the value defined in one place.
+/// </summary>
+internal static class PollingDefaults
+{
+    /// <summary>
+    /// Default poll cadence in milliseconds.
+    /// </summary>
+    internal const int PollDelayMs = 25;
+}

--- a/base/Annium/src/Annium/Threading/Tasks/TaskSet.cs
+++ b/base/Annium/src/Annium/Threading/Tasks/TaskSet.cs
@@ -2,7 +2,9 @@ using System.Threading.Tasks;
 
 namespace Annium.Threading.Tasks;
 
-// TaskSet uses task.Result after Task.WhenAll guarantees completion; naming follows tuple-return convention not async suffix.
+// TaskSet uses task.Result after Task.WhenAll guarantees completion (VSTHRD103); awaits caller-supplied
+// tasks via Task.WhenAll, not locally-created ones (VSTHRD003); naming follows tuple-return convention,
+// not the async suffix (VSTHRD200).
 #pragma warning disable VSTHRD200
 #pragma warning disable VSTHRD103
 #pragma warning disable VSTHRD003

--- a/base/Annium/src/Annium/Threading/Tasks/Wait.cs
+++ b/base/Annium/src/Annium/Threading/Tasks/Wait.cs
@@ -10,18 +10,17 @@ namespace Annium.Threading.Tasks;
 public static class Wait
 {
     /// <summary>
-    /// Default poll cadence in milliseconds shared by every condition-polling overload below.
-    /// </summary>
-    private const int DefaultPollDelayMs = 25;
-
-    /// <summary>
     /// Awaits while the condition is true or the task is canceled.
     /// </summary>
     /// <param name="condition">The condition that will perpetuate the block.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <param name="pollDelay">The delay at which the condition will be polled, in milliseconds.</param>
     /// <returns>A task that completes when the condition is false or canceled.</returns>
-    public static async Task WhileAsync(Func<bool> condition, CancellationToken ct, int pollDelay = DefaultPollDelayMs)
+    public static async Task WhileAsync(
+        Func<bool> condition,
+        CancellationToken ct,
+        int pollDelay = PollingDefaults.PollDelayMs
+    )
     {
         try
         {
@@ -73,7 +72,7 @@ public static class Wait
     public static async Task WhileAsync(
         Func<ValueTask<bool>> condition,
         CancellationToken ct,
-        int pollDelay = DefaultPollDelayMs
+        int pollDelay = PollingDefaults.PollDelayMs
     )
     {
         try
@@ -123,7 +122,11 @@ public static class Wait
     /// <param name="ct">Cancellation token.</param>
     /// <param name="pollDelay">The delay at which the condition will be polled, in milliseconds.</param>
     /// <returns>A task that completes when the condition is true or canceled.</returns>
-    public static async Task UntilAsync(Func<bool> condition, CancellationToken ct, int pollDelay = DefaultPollDelayMs)
+    public static async Task UntilAsync(
+        Func<bool> condition,
+        CancellationToken ct,
+        int pollDelay = PollingDefaults.PollDelayMs
+    )
     {
         try
         {
@@ -175,7 +178,7 @@ public static class Wait
     public static async Task UntilAsync(
         Func<ValueTask<bool>> condition,
         CancellationToken ct,
-        int pollDelay = DefaultPollDelayMs
+        int pollDelay = PollingDefaults.PollDelayMs
     )
     {
         try

--- a/base/Annium/tests/Annium.Tests/Threading/Tasks/WaitTests.cs
+++ b/base/Annium/tests/Annium.Tests/Threading/Tasks/WaitTests.cs
@@ -116,4 +116,48 @@ public class WaitTests
         sw.Stop();
         (sw.ElapsedMilliseconds >= 150 && sw.ElapsedMilliseconds < 2000).IsTrue();
     }
+
+    /// <summary>
+    /// Verifies that the async-condition overload of WhileAsync completes immediately when the condition is already false.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task WhileAsync_AsyncCondition_ConditionImmediatelyFalse_CompletesImmediately()
+    {
+        var sw = Stopwatch.StartNew();
+        await Wait.WhileAsync(() => new ValueTask<bool>(false), ms: 5000);
+        sw.Stop();
+
+        // First check is false — the loop body (and its poll delay) is never entered.
+        (sw.ElapsedMilliseconds < 1000).IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies that the async-condition overload of WhileAsync exits when the condition flips to false,
+    /// rather than relying on the timeout — locks the <c>await condition()</c> result driving the loop exit.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task WhileAsync_AsyncCondition_ConditionBecomesFalse_Completes()
+    {
+        var flipAt = DateTime.UtcNow.AddMilliseconds(100);
+        await Wait.WhileAsync(() => new ValueTask<bool>(DateTime.UtcNow < flipAt), ms: 5000, pollDelay: 10);
+
+        // Reaching here without timing out means the loop exited on the condition flipping false, not the 5s timeout.
+        (DateTime.UtcNow >= flipAt).IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies that the async-condition overload of UntilAsync completes as soon as the condition flips to true.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task UntilAsync_AsyncCondition_ConditionFlips_Completes()
+    {
+        var flipAt = DateTime.UtcNow.AddMilliseconds(100);
+        await Wait.UntilAsync(() => new ValueTask<bool>(DateTime.UtcNow >= flipAt), ms: 5000, pollDelay: 10);
+
+        // Reaching here without timing out means the loop exited on the condition flipping true, not the 5s timeout.
+        (DateTime.UtcNow >= flipAt).IsTrue();
+    }
 }

--- a/base/Configuration/src/Annium.Configuration.Abstractions/ConfigurationContainerExtensions.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/ConfigurationContainerExtensions.cs
@@ -38,7 +38,8 @@ public static class ConfigurationContainerExtensions
     /// Loads every registered source in parallel, then merges results in registration order
     /// (later sources override earlier ones). Sources marked <c>Optional</c> swallow load
     /// failures and contribute an empty dictionary; any non-optional failures surface as a
-    /// single <see cref="AggregateException"/>.
+    /// single <see cref="AggregateException"/>. Caller-requested cancellation propagates as
+    /// <see cref="OperationCanceledException"/> regardless of any source's <c>Optional</c> flag.
     /// </summary>
     /// <param name="container">Container whose sources to flush</param>
     /// <param name="ct">Cancellation token forwarded to each source</param>
@@ -56,6 +57,11 @@ public static class ConfigurationContainerExtensions
                 {
                     var data = await s.LoadAsync(ct);
                     return (source: s, data, error: null);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // caller-requested cancellation must propagate regardless of source.Optional
+                    throw;
                 }
                 catch (Exception ex)
                 {

--- a/base/Configuration/src/Annium.Configuration.Abstractions/ConfigurationContainerExtensions.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/ConfigurationContainerExtensions.cs
@@ -66,7 +66,7 @@ public static class ConfigurationContainerExtensions
 
         var results = await Task.WhenAll(loads);
 
-        var failures = results.Where(r => r.error is not null && !r.source.Optional).Select(r => r.error!).ToArray();
+        var failures = results.Where(r => !r.source.Optional).Select(r => r.error).OfType<Exception>().ToArray();
 
         if (failures.Length > 0)
             throw new AggregateException("Configuration source(s) failed to load", failures);

--- a/base/Configuration/src/Annium.Configuration.Abstractions/ConfigurationFactory.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/ConfigurationFactory.cs
@@ -1,0 +1,16 @@
+using Annium.Configuration.Abstractions.Internal;
+
+namespace Annium.Configuration.Abstractions;
+
+/// <summary>
+/// Factory methods for the configuration system. Provides a public path to obtain an empty
+/// <see cref="IConfigurationContainer"/> without referencing internal implementation types.
+/// </summary>
+public static class ConfigurationFactory
+{
+    /// <summary>
+    /// Creates an empty <see cref="IConfigurationContainer"/>.
+    /// </summary>
+    /// <returns>A new empty configuration container.</returns>
+    public static IConfigurationContainer CreateContainer() => new ConfigurationContainer();
+}

--- a/base/Configuration/src/Annium.Configuration.Abstractions/ConfigurationProviderBase.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/ConfigurationProviderBase.cs
@@ -4,37 +4,72 @@ using System.Linq;
 namespace Annium.Configuration.Abstractions;
 
 /// <summary>
-/// Base class for configuration providers that read configuration data from various sources
+/// Base class for configuration providers that read configuration data from various sources.
+/// Subclasses produce flattened key-value data by entering/leaving named scopes with
+/// <see cref="Push"/> / <see cref="Pop"/> and writing leaf values with <see cref="Set"/>.
 /// </summary>
 public abstract class ConfigurationProviderBase
 {
     /// <summary>
-    /// Dictionary storing configuration data with key paths and string values
+    /// Flattened key-value store. Owned by the base — never reassigned, only cleared on <see cref="Init"/>.
     /// </summary>
-    protected Dictionary<string[], string> Data = new();
+    private readonly Dictionary<string[], string> _data = new();
 
     /// <summary>
-    /// Stack maintaining the current path context during configuration processing
+    /// Context stack used to build the current key path. Owned by the base — never reassigned, only cleared on <see cref="Init"/>.
     /// </summary>
-    protected Stack<string> Context = new();
+    private readonly Stack<string> _context = new();
 
     /// <summary>
-    /// Gets the current path as an array of strings from the context stack
+    /// Gets the current path as an array of strings from the context stack.
     /// </summary>
-    protected string[] Path => Context.Reverse().ToArray();
+    protected string[] Path => _context.Reverse().ToArray();
 
     /// <summary>
-    /// Reads configuration data from the source and returns it as a dictionary
+    /// Snapshot of the accumulated data, suitable for returning from <see cref="Read"/>.
+    /// Returns a fresh dictionary copy each access — the caller's reference is not aliased to
+    /// the live <c>_data</c> field, so a subsequent <see cref="Read"/> cannot mutate it.
+    /// </summary>
+    protected IReadOnlyDictionary<string[], string> Result => new Dictionary<string[], string>(_data);
+
+    /// <summary>
+    /// Reads configuration data from the source and returns it as a dictionary.
     /// </summary>
     /// <returns>Dictionary containing configuration keys and values</returns>
     public abstract IReadOnlyDictionary<string[], string> Read();
 
     /// <summary>
-    /// Initializes the configuration provider by resetting data and context
+    /// Resets the provider state so the same instance can be re-read deterministically.
+    /// Subclasses call this at the top of <see cref="Read"/>.
     /// </summary>
     protected void Init()
     {
-        Data = new Dictionary<string[], string>();
-        Context = new Stack<string>();
+        _data.Clear();
+        _context.Clear();
     }
+
+    /// <summary>
+    /// Pushes a new segment onto the current context path.
+    /// </summary>
+    /// <param name="segment">Path segment to push.</param>
+    protected void Push(string segment) => _context.Push(segment);
+
+    /// <summary>
+    /// Pops the most recently pushed segment off the context path.
+    /// </summary>
+    protected void Pop() => _context.Pop();
+
+    /// <summary>
+    /// Writes a leaf value at the current <see cref="Path"/>.
+    /// </summary>
+    /// <param name="value">Value to write.</param>
+    protected void Set(string value) => _data[Path] = value;
+
+    /// <summary>
+    /// Writes a leaf value at an explicit path. Use when the subclass builds its own
+    /// key path instead of accumulating it through <see cref="Push"/> / <see cref="Pop"/>.
+    /// </summary>
+    /// <param name="path">Explicit key path.</param>
+    /// <param name="value">Value to write.</param>
+    protected void SetAt(string[] path, string value) => _data[path] = value;
 }

--- a/base/Configuration/src/Annium.Configuration.Abstractions/ConfigurationProviderBase.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/ConfigurationProviderBase.cs
@@ -26,6 +26,11 @@ public abstract class ConfigurationProviderBase
     protected string[] Path => _context.Reverse().ToArray();
 
     /// <summary>
+    /// Gets the current path joined with <c>'.'</c>, for use in diagnostic messages.
+    /// </summary>
+    protected string PathString => string.Join('.', Path);
+
+    /// <summary>
     /// Snapshot of the accumulated data, suitable for returning from <see cref="Read"/>.
     /// Returns a fresh dictionary copy each access — the caller's reference is not aliased to
     /// the live <c>_data</c> field, so a subsequent <see cref="Read"/> cannot mutate it.

--- a/base/Configuration/src/Annium.Configuration.Abstractions/FileConfigurationSourceBase.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/FileConfigurationSourceBase.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Annium.Configuration.Abstractions;
+
+/// <summary>
+/// Base class for deferred configuration sources that read a local file at <see cref="LoadAsync"/> time.
+/// </summary>
+public abstract class FileConfigurationSourceBase : IConfigurationSource
+{
+    /// <summary>Absolute path to the configuration file.</summary>
+    private readonly string _path;
+
+    /// <summary>Whether a missing/unreadable file is silenced.</summary>
+    public bool Optional { get; }
+
+    /// <summary>Format label used in diagnostic messages (e.g. "Json", "Yaml").</summary>
+    protected abstract string FormatLabel { get; }
+
+    /// <summary>
+    /// Parses the file contents into the flattened configuration dictionary.
+    /// </summary>
+    /// <param name="raw">Raw text read from the file.</param>
+    /// <returns>Flattened configuration data.</returns>
+    protected abstract IReadOnlyDictionary<string[], string> ParseRaw(string raw);
+
+    /// <summary>Initializes a new instance of <see cref="FileConfigurationSourceBase"/>.</summary>
+    /// <param name="path">Path to the configuration file (resolved to absolute).</param>
+    /// <param name="optional">Whether a missing file is silenced.</param>
+    protected FileConfigurationSourceBase(string path, bool optional)
+    {
+        _path = Path.GetFullPath(path);
+        Optional = optional;
+    }
+
+    /// <summary>
+    /// Reads the file and flattens it. Throws <see cref="FileNotFoundException"/> when the file
+    /// is absent (caller decides whether to swallow via <see cref="IConfigurationSource.Optional"/>).
+    /// </summary>
+    /// <param name="ct">Cancellation token forwarded to the file read.</param>
+    /// <returns>Flattened configuration.</returns>
+    public async ValueTask<IReadOnlyDictionary<string[], string>> LoadAsync(CancellationToken ct)
+    {
+        if (!File.Exists(_path))
+            throw new FileNotFoundException(
+                $"{FormatLabel} configuration file {_path} not found and is not optional",
+                _path
+            );
+
+        var raw = await File.ReadAllTextAsync(_path, ct);
+        return ParseRaw(raw);
+    }
+}

--- a/base/Configuration/src/Annium.Configuration.Abstractions/IConfigurationBuilder.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/IConfigurationBuilder.cs
@@ -1,10 +1,18 @@
+using System.Collections.Generic;
+
 namespace Annium.Configuration.Abstractions;
 
 /// <summary>
-/// Interface for building configuration objects from configuration data
+/// Interface for building configuration objects from pre-merged configuration data
 /// </summary>
-public interface IConfigurationBuilder : IConfigurationContainer
+public interface IConfigurationBuilder
 {
+    /// <summary>
+    /// Adds pre-merged configuration data to be processed by <see cref="Build{T}"/>.
+    /// </summary>
+    /// <param name="config">Configuration data to add</param>
+    void Add(IReadOnlyDictionary<string[], string> config);
+
     /// <summary>
     /// Builds an instance of type T from the configuration data
     /// </summary>

--- a/base/Configuration/src/Annium.Configuration.Abstractions/IConfigurationContainer.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/IConfigurationContainer.cs
@@ -21,15 +21,13 @@ public interface IConfigurationContainer
     /// this container in registration order.
     /// </summary>
     /// <param name="source">Source to register</param>
-    /// <returns>The container for method chaining</returns>
-    IConfigurationContainer AddSource(IConfigurationSource source);
+    void AddSource(IConfigurationSource source);
 
     /// <summary>
     /// Adds configuration data to the container
     /// </summary>
     /// <param name="config">Configuration data to add</param>
-    /// <returns>The container for method chaining</returns>
-    IConfigurationContainer Add(IReadOnlyDictionary<string[], string> config);
+    void Add(IReadOnlyDictionary<string[], string> config);
 
     /// <summary>
     /// Gets all configuration data from the container

--- a/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationBuilder.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationBuilder.cs
@@ -37,27 +37,10 @@ internal class ConfigurationBuilder : IConfigurationBuilder
     }
 
     /// <summary>
-    /// Sources registered for deferred loading on the underlying container.
-    /// </summary>
-    public IReadOnlyList<IConfigurationSource> Sources => _container.Sources;
-
-    /// <summary>
-    /// Registers a deferred configuration source on the underlying container.
-    /// </summary>
-    /// <param name="source">Source to register</param>
-    public void AddSource(IConfigurationSource source) => _container.AddSource(source);
-
-    /// <summary>
-    /// Adds configuration data to the container
+    /// Adds configuration data to the builder's data store.
     /// </summary>
     /// <param name="config">Configuration data to add</param>
     public void Add(IReadOnlyDictionary<string[], string> config) => _container.Add(config);
-
-    /// <summary>
-    /// Gets all configuration data from the container
-    /// </summary>
-    /// <returns>Dictionary containing all configuration data</returns>
-    public IReadOnlyDictionary<string[], string> Get() => _container.Get();
 
     /// <summary>
     /// Builds an instance of type T from the configuration data

--- a/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationBuilder.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationBuilder.cs
@@ -37,19 +37,6 @@ internal class ConfigurationBuilder : IConfigurationBuilder
     }
 
     /// <summary>
-    /// Initializes a new instance of ConfigurationBuilder with an existing container
-    /// </summary>
-    /// <param name="typeManager">Type manager for type resolution</param>
-    /// <param name="mapper">Mapper for data conversion</param>
-    /// <param name="container">Existing configuration container</param>
-    internal ConfigurationBuilder(ITypeManager typeManager, IMapper mapper, IConfigurationContainer container)
-    {
-        _typeManager = typeManager;
-        _mapper = mapper;
-        _container = container;
-    }
-
-    /// <summary>
     /// Sources registered for deferred loading on the underlying container.
     /// </summary>
     public IReadOnlyList<IConfigurationSource> Sources => _container.Sources;
@@ -58,15 +45,13 @@ internal class ConfigurationBuilder : IConfigurationBuilder
     /// Registers a deferred configuration source on the underlying container.
     /// </summary>
     /// <param name="source">Source to register</param>
-    /// <returns>The container for method chaining</returns>
-    public IConfigurationContainer AddSource(IConfigurationSource source) => _container.AddSource(source);
+    public void AddSource(IConfigurationSource source) => _container.AddSource(source);
 
     /// <summary>
     /// Adds configuration data to the container
     /// </summary>
     /// <param name="config">Configuration data to add</param>
-    /// <returns>The container for method chaining</returns>
-    public IConfigurationContainer Add(IReadOnlyDictionary<string[], string> config) => _container.Add(config);
+    public void Add(IReadOnlyDictionary<string[], string> config) => _container.Add(config);
 
     /// <summary>
     /// Gets all configuration data from the container

--- a/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationContainer.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationContainer.cs
@@ -10,7 +10,7 @@ internal sealed class ConfigurationContainer : IConfigurationContainer
     /// <summary>
     /// Dictionary storing configuration data with custom key comparer
     /// </summary>
-    private readonly IDictionary<string[], string> _config = new Dictionary<string[], string>(new KeyComparer());
+    private readonly Dictionary<string[], string> _config = new(new KeyComparer());
 
     /// <summary>
     /// Backing list for registered deferred sources, in registration order.

--- a/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationContainer.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationContainer.cs
@@ -26,24 +26,19 @@ internal sealed class ConfigurationContainer : IConfigurationContainer
     /// Registers a deferred configuration source.
     /// </summary>
     /// <param name="source">Source to register</param>
-    /// <returns>The container for method chaining</returns>
-    public IConfigurationContainer AddSource(IConfigurationSource source)
+    public void AddSource(IConfigurationSource source)
     {
         _sources.Add(source);
-        return this;
     }
 
     /// <summary>
     /// Adds configuration data to the container
     /// </summary>
     /// <param name="config">Configuration data to add</param>
-    /// <returns>The container for method chaining</returns>
-    public IConfigurationContainer Add(IReadOnlyDictionary<string[], string> config)
+    public void Add(IReadOnlyDictionary<string[], string> config)
     {
         foreach (var (key, value) in config)
             _config[key] = value;
-
-        return this;
     }
 
     /// <summary>

--- a/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationContainer.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationContainer.cs
@@ -5,7 +5,7 @@ namespace Annium.Configuration.Abstractions.Internal;
 /// <summary>
 /// Implementation of IConfigurationContainer that stores configuration data in memory
 /// </summary>
-public class ConfigurationContainer : IConfigurationContainer
+internal sealed class ConfigurationContainer : IConfigurationContainer
 {
     /// <summary>
     /// Dictionary storing configuration data with custom key comparer

--- a/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationProcessor.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Annium.Core.Mapper;
 using Annium.Core.Runtime.Types;
 using Annium.Reflection;
@@ -204,12 +205,35 @@ internal class ConfigurationProcessor<T>
 
         // Activator.CreateInstance is BCL-guaranteed non-null for concrete reference types; abstract path resolved via ResolveByKey above
         var result = Activator.CreateInstance(type)!;
-        var properties = type.GetProperties().Where(e => e.CanWrite).ToArray();
+
+        // Mirror ObjectConfigurationProvider's flattener exactly: it enumerates members via
+        // GetAllProperties/GetAllFields (own + interface-declared). DistinctBy(Name) collapses the
+        // interface/class duplicates those return, keeping the concrete member (enumerated first).
+        // Exclude interface-declared PropertyInfo (e.g. unoverridden default-interface-method
+        // properties): SetValue on those against a concrete instance throws. The class's own
+        // implementation of an interface property is enumerated first and kept by DistinctBy.
+        var properties = type.GetAllProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(e => e.CanWrite && e.DeclaringType is { IsInterface: false })
+            .DistinctBy(e => e.Name)
+            .ToArray();
         foreach (var property in properties)
         {
             _context.Push(property.Name);
             if (KeyExists())
                 property.SetValue(result, Process(property.PropertyType));
+            _context.Pop();
+        }
+
+        // Public instance fields (e.g. ValueTuple's Item1/Item2) are flattened too, so restore them.
+        var fields = type.GetAllFields(BindingFlags.Public | BindingFlags.Instance)
+            .Where(e => !e.IsInitOnly)
+            .DistinctBy(e => e.Name)
+            .ToArray();
+        foreach (var field in fields)
+        {
+            _context.Push(field.Name);
+            if (KeyExists())
+                field.SetValue(result, Process(field.FieldType));
             _context.Pop();
         }
 

--- a/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationProcessor.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationProcessor.cs
@@ -101,6 +101,7 @@ internal class ConfigurationProcessor<T>
 
         // var items = config.Where(e => e.Key.StartsWith(path, StringComparison.OrdinalIgnoreCase) && e.Key.Length > path.Length).ToArray();
         var items = GetDescendants();
+        // Activator.CreateInstance returns non-null for concrete Dictionary<,> (never Nullable<T>)
         var result = (IDictionary)Activator.CreateInstance(type)!;
 
         foreach (var name in items)
@@ -125,6 +126,7 @@ internal class ConfigurationProcessor<T>
     private object ProcessList(Type type)
     {
         var elementType = type.GetGenericArguments()[0];
+        // Activator.CreateInstance returns non-null for concrete List<> (never Nullable<T>)
         var result = (IList)Activator.CreateInstance(type)!;
 
         var items = GetDescendants();
@@ -146,6 +148,7 @@ internal class ConfigurationProcessor<T>
     /// <returns>Configured array instance</returns>
     private object ProcessArray(Type type)
     {
+        // type.IsArray is true here (dispatched from Process); GetElementType is BCL-guaranteed non-null for arrays
         var elementType = type.GetElementType()!;
         var raw = (IList)ProcessList(typeof(List<>).MakeGenericType(elementType));
 
@@ -161,8 +164,8 @@ internal class ConfigurationProcessor<T>
     /// Processes configuration data for object types
     /// </summary>
     /// <param name="type">Object type to process</param>
-    /// <returns>Configured object instance</returns>
-    private object ProcessObject(Type type)
+    /// <returns>Configured object instance, or null when an abstract type's resolution key is absent from the configuration</returns>
+    private object? ProcessObject(Type type)
     {
         if (type.IsAbstract || type.IsInterface)
         {
@@ -174,14 +177,19 @@ internal class ConfigurationProcessor<T>
             var hasKey = _config.TryGetValue(Path, out var rawKey);
             _context.Pop();
             if (!hasKey || rawKey is null)
-                return null!;
+                return null; // sentinel for abstract type with absent resolution key; Process<T>() at line 65 converts to InvalidOperationException
 
-            var key = _mapper.Map(rawKey, resolutionKeyProperty.PropertyType);
+            var key =
+                _mapper.Map(rawKey, resolutionKeyProperty.PropertyType)
+                ?? throw new InvalidOperationException(
+                    $"Resolution key mapper returned null for raw value '{rawKey}' of type {resolutionKeyProperty.PropertyType}"
+                );
             type =
-                _typeManager.ResolveByKey(key!, type)
+                _typeManager.ResolveByKey(key, type)
                 ?? throw new ArgumentException($"Can't resolve abstract type {type} with key {key}");
         }
 
+        // Activator.CreateInstance is BCL-guaranteed non-null for concrete reference types; abstract path resolved via ResolveByKey above
         var result = Activator.CreateInstance(type)!;
         var properties = type.GetProperties().Where(e => e.CanWrite).ToArray();
         foreach (var property in properties)

--- a/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationProcessor.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationProcessor.cs
@@ -129,7 +129,20 @@ internal class ConfigurationProcessor<T>
         // Activator.CreateInstance returns non-null for concrete List<> (never Nullable<T>)
         var result = (IList)Activator.CreateInstance(type)!;
 
-        var items = GetDescendants();
+        // GetDescendants returns dictionary keys in arbitrary order; list reconstruction requires
+        // numeric ordering so that List<T> indices (0, 1, 2, ..., 10, 11) reassemble correctly
+        // — and not lexicographically ("10" < "2"). Non-integer keys at a list path indicate
+        // malformed source data and are rejected with path context.
+        var items = GetDescendants()
+            .Select(key =>
+                int.TryParse(key, out var idx)
+                    ? idx
+                    : throw new InvalidOperationException(
+                        $"List index '{key}' at path {string.Join('.', Path)} is not a valid integer"
+                    )
+            )
+            .OrderBy(i => i)
+            .Select(i => i.ToString());
 
         foreach (var index in items)
         {

--- a/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationProcessor.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ConfigurationProcessor.cs
@@ -62,7 +62,13 @@ internal class ConfigurationProcessor<T>
     /// <returns>Configured instance of type T</returns>
     public T Process()
     {
-        return (T)(Process(typeof(T)) ?? default!);
+        var result = Process(typeof(T));
+        if (result is null)
+            throw new InvalidOperationException(
+                $"Configuration produced null for type {typeof(T)}. "
+                    + "This typically means an abstract type was requested but the resolution key was absent from the configuration."
+            );
+        return (T)result;
     }
 
     /// <summary>

--- a/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ObjectConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ObjectConfigurationProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Annium;
 using Annium.Reflection;
 
 namespace Annium.Configuration.Abstractions.Internal;
@@ -13,6 +14,8 @@ namespace Annium.Configuration.Abstractions.Internal;
 /// </summary>
 internal class ObjectConfigurationProvider : ConfigurationProviderBase
 {
+    private static readonly object[] _noArgs = Array.Empty<object>();
+
     /// <summary>
     /// The configuration object to read data from
     /// </summary>
@@ -109,20 +112,33 @@ internal class ObjectConfigurationProvider : ConfigurationProviderBase
         var dictionaryType =
             type.GetTargetImplementation(typeof(IDictionary<,>))
             ?? type.GetTargetImplementation(typeof(IReadOnlyDictionary<,>));
-        var keyType = dictionaryType!.GetGenericArguments()[0];
+        if (dictionaryType is null)
+            throw new InvalidOperationException(
+                $"Value of type {type} is not assignable to IDictionary<,> or IReadOnlyDictionary<,>"
+            );
+        var keyType = dictionaryType.GetGenericArguments()[0];
         var valueType = dictionaryType.GetGenericArguments()[1];
         var keyValueType = typeof(KeyValuePair<,>).MakeGenericType(keyType, valueType);
-        var getKey = keyValueType.GetProperty(nameof(KeyValuePair<,>.Key))!.GetMethod!;
-        var getValue = keyValueType.GetProperty(nameof(KeyValuePair<,>.Value))!.GetMethod!;
+        var getKey = keyValueType.GetProperty(nameof(KeyValuePair<,>.Key)).NotNull().GetMethod.NotNull();
+        var getValue = keyValueType.GetProperty(nameof(KeyValuePair<,>.Value)).NotNull().GetMethod.NotNull();
 
         foreach (var item in (IEnumerable)value)
         {
-            var itemValue = getValue.Invoke(item, Array.Empty<object>());
+            var itemValue = getValue.Invoke(item, _noArgs);
             if (itemValue is null)
                 continue;
 
-            var itemKey = getKey.Invoke(item, Array.Empty<object>())!;
-            var memberPath = prefix.Append(itemKey.ToString()!).ToArray();
+            var itemKey =
+                getKey.Invoke(item, _noArgs)
+                ?? throw new InvalidOperationException(
+                    $"Dictionary key is null at path: {string.Join('.', prefix)}"
+                );
+            var keyText =
+                itemKey.ToString()
+                ?? throw new InvalidOperationException(
+                    $"Key.ToString() returned null for type {itemKey.GetType().FullName} at path: {string.Join('.', prefix)}"
+                );
+            var memberPath = prefix.Append(keyText).ToArray();
 
             Process(memberPath, addValue, itemValue);
         }
@@ -158,8 +174,8 @@ internal class ObjectConfigurationProvider : ConfigurationProviderBase
     private void ProcessNullable(string[] prefix, Action<string[], string> addValue, object value)
     {
         var type = value.GetType();
-        var getValueOrDefault = type.GetMethod(nameof(Nullable<>.GetValueOrDefault), Type.EmptyTypes)!;
-        var innerValue = getValueOrDefault.Invoke(value, Array.Empty<object>());
+        var getValueOrDefault = type.GetMethod(nameof(Nullable<>.GetValueOrDefault), Type.EmptyTypes).NotNull();
+        var innerValue = getValueOrDefault.Invoke(value, _noArgs);
         if (innerValue is null)
             return;
 
@@ -211,8 +227,7 @@ file static class Helper
     /// </summary>
     /// <param name="type">Type to get members for</param>
     /// <returns>Collection of accessible members</returns>
-    public static IReadOnlyCollection<MemberInfo> GetMembers(Type type) =>
-        _members.GetOrAdd(type, ResolveMembers);
+    public static IReadOnlyCollection<MemberInfo> GetMembers(Type type) => _members.GetOrAdd(type, ResolveMembers);
 
     /// <summary>
     /// Resolves the type variant for a type

--- a/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ObjectConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ObjectConfigurationProvider.cs
@@ -36,21 +36,20 @@ internal class ObjectConfigurationProvider : ConfigurationProviderBase
     /// <returns>Dictionary containing configuration keys and values</returns>
     public override IReadOnlyDictionary<string[], string> Read()
     {
-        var result = new Dictionary<string[], string>();
+        Init();
 
         if (_config is not null)
-            Process(Array.Empty<string>(), result.Add, _config);
+            Process(Array.Empty<string>(), _config);
 
-        return result;
+        return Result;
     }
 
     /// <summary>
     /// Processes an object value and adds its data to the configuration
     /// </summary>
     /// <param name="prefix">Key prefix for the current path</param>
-    /// <param name="addValue">Action to add key-value pairs</param>
     /// <param name="value">Object value to process</param>
-    private void Process(string[] prefix, Action<string[], string> addValue, object? value)
+    private void Process(string[] prefix, object? value)
     {
         if (value is null)
             return;
@@ -60,19 +59,19 @@ internal class ObjectConfigurationProvider : ConfigurationProviderBase
         switch (variant)
         {
             case TypeVariant.Object:
-                ProcessObject(prefix, addValue, value);
+                ProcessObject(prefix, value);
                 break;
             case TypeVariant.Dictionary:
-                ProcessDictionary(prefix, addValue, value);
+                ProcessDictionary(prefix, value);
                 break;
             case TypeVariant.Enumerable:
-                ProcessEnumerable(prefix, addValue, value);
+                ProcessEnumerable(prefix, value);
                 break;
             case TypeVariant.Nullable:
-                ProcessNullable(prefix, addValue, value);
+                ProcessNullable(prefix, value);
                 break;
             case TypeVariant.Primitive:
-                ProcessPrimitive(prefix, addValue, value);
+                ProcessPrimitive(prefix, value);
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(variant), $"Can't process type {type.FriendlyName()}");
@@ -83,9 +82,8 @@ internal class ObjectConfigurationProvider : ConfigurationProviderBase
     /// Processes an object by iterating through its properties and fields
     /// </summary>
     /// <param name="prefix">Key prefix for the current path</param>
-    /// <param name="addValue">Action to add key-value pairs</param>
     /// <param name="value">Object to process</param>
-    private void ProcessObject(string[] prefix, Action<string[], string> addValue, object value)
+    private void ProcessObject(string[] prefix, object value)
     {
         var type = value.GetType();
         var members = Helper.GetMembers(type);
@@ -96,7 +94,7 @@ internal class ObjectConfigurationProvider : ConfigurationProviderBase
             var memberValue = member.GetPropertyOrFieldValue(value);
 
             if (memberValue is not null)
-                Process(memberPath, addValue, memberValue);
+                Process(memberPath, memberValue);
         }
     }
 
@@ -104,9 +102,8 @@ internal class ObjectConfigurationProvider : ConfigurationProviderBase
     /// Processes a dictionary by iterating through its key-value pairs
     /// </summary>
     /// <param name="prefix">Key prefix for the current path</param>
-    /// <param name="addValue">Action to add key-value pairs</param>
     /// <param name="value">Dictionary to process</param>
-    private void ProcessDictionary(string[] prefix, Action<string[], string> addValue, object value)
+    private void ProcessDictionary(string[] prefix, object value)
     {
         var type = value.GetType();
         var dictionaryType =
@@ -138,7 +135,7 @@ internal class ObjectConfigurationProvider : ConfigurationProviderBase
                 );
             var memberPath = prefix.Append(keyText).ToArray();
 
-            Process(memberPath, addValue, itemValue);
+            Process(memberPath, itemValue);
         }
     }
 
@@ -146,9 +143,8 @@ internal class ObjectConfigurationProvider : ConfigurationProviderBase
     /// Processes an enumerable by iterating through its items with indices
     /// </summary>
     /// <param name="prefix">Key prefix for the current path</param>
-    /// <param name="addValue">Action to add key-value pairs</param>
     /// <param name="value">Enumerable to process</param>
-    private void ProcessEnumerable(string[] prefix, Action<string[], string> addValue, object value)
+    private void ProcessEnumerable(string[] prefix, object value)
     {
         var index = 0;
 
@@ -159,7 +155,7 @@ internal class ObjectConfigurationProvider : ConfigurationProviderBase
 
             var memberPath = prefix.Append((index++).ToString()).ToArray();
 
-            Process(memberPath, addValue, item);
+            Process(memberPath, item);
         }
     }
 
@@ -167,9 +163,8 @@ internal class ObjectConfigurationProvider : ConfigurationProviderBase
     /// Processes a nullable value by extracting its underlying value
     /// </summary>
     /// <param name="prefix">Key prefix for the current path</param>
-    /// <param name="addValue">Action to add key-value pairs</param>
     /// <param name="value">Nullable value to process</param>
-    private void ProcessNullable(string[] prefix, Action<string[], string> addValue, object value)
+    private void ProcessNullable(string[] prefix, object value)
     {
         var type = value.GetType();
         var getValueOrDefault = type.GetMethod(nameof(Nullable<>.GetValueOrDefault), Type.EmptyTypes).NotNull();
@@ -177,22 +172,21 @@ internal class ObjectConfigurationProvider : ConfigurationProviderBase
         if (innerValue is null)
             return;
 
-        Process(prefix, addValue, innerValue);
+        Process(prefix, innerValue);
     }
 
     /// <summary>
     /// Processes a primitive value by converting it to string
     /// </summary>
     /// <param name="prefix">Key prefix for the current path</param>
-    /// <param name="addValue">Action to add key-value pairs</param>
     /// <param name="value">Primitive value to process</param>
-    private void ProcessPrimitive(string[] prefix, Action<string[], string> addValue, object value)
+    private void ProcessPrimitive(string[] prefix, object value)
     {
         var valueString = value.ToString();
         if (valueString is null)
             return;
 
-        addValue(prefix, valueString);
+        SetAt(prefix, valueString);
     }
 }
 

--- a/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ObjectConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ObjectConfigurationProvider.cs
@@ -255,7 +255,13 @@ file static class Helper
     {
         return type.GetAllProperties(BindingFlags.Public | BindingFlags.Instance)
             .Where(x => x.CanRead && x.GetMethod?.GetParameters().Length == 0)
-            .Concat(type.GetAllFields(BindingFlags.Public | BindingFlags.Instance).OfType<MemberInfo>())
+            // readonly fields are skipped by ConfigurationProcessor.ProcessObject's restore (it filters
+            // !IsInitOnly); excluding them here keeps the flatten and restore member sets symmetric.
+            .Concat(
+                type.GetAllFields(BindingFlags.Public | BindingFlags.Instance)
+                    .Where(f => !f.IsInitOnly)
+                    .OfType<MemberInfo>()
+            )
             .ToArray();
     }
 }

--- a/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ObjectConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ObjectConfigurationProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -187,44 +188,31 @@ internal class ObjectConfigurationProvider : ConfigurationProviderBase
 file static class Helper
 {
     /// <summary>
-    /// Cache for type variants to improve performance
+    /// Cache for type variants to improve performance. ConcurrentDictionary is required because
+    /// BuildAsync loads sources in parallel via Task.WhenAll, so Read() may run concurrently.
     /// </summary>
-    private static readonly Dictionary<Type, TypeVariant> _variants = new();
+    private static readonly ConcurrentDictionary<Type, TypeVariant> _variants = new();
 
     /// <summary>
-    /// Cache for type members to improve performance
+    /// Cache for type members to improve performance. ConcurrentDictionary is required because
+    /// BuildAsync loads sources in parallel via Task.WhenAll, so Read() may run concurrently.
     /// </summary>
-    private static readonly Dictionary<Type, IReadOnlyCollection<MemberInfo>> _members = new();
+    private static readonly ConcurrentDictionary<Type, IReadOnlyCollection<MemberInfo>> _members = new();
 
     /// <summary>
     /// Gets the type variant for a given type
     /// </summary>
     /// <param name="type">Type to get variant for</param>
     /// <returns>Type variant of the specified type</returns>
-    public static TypeVariant GetVariant(Type type)
-    {
-        if (_variants.TryGetValue(type, out var variant))
-            return variant;
-
-        _variants[type] = variant = ResolveVariant(type);
-
-        return variant;
-    }
+    public static TypeVariant GetVariant(Type type) => _variants.GetOrAdd(type, ResolveVariant);
 
     /// <summary>
     /// Gets the accessible members for a given type
     /// </summary>
     /// <param name="type">Type to get members for</param>
     /// <returns>Collection of accessible members</returns>
-    public static IReadOnlyCollection<MemberInfo> GetMembers(Type type)
-    {
-        if (_members.TryGetValue(type, out var members))
-            return members;
-
-        _members[type] = members = ResolveMembers(type);
-
-        return members;
-    }
+    public static IReadOnlyCollection<MemberInfo> GetMembers(Type type) =>
+        _members.GetOrAdd(type, ResolveMembers);
 
     /// <summary>
     /// Resolves the type variant for a type

--- a/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ObjectConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/Internal/ObjectConfigurationProvider.cs
@@ -130,9 +130,7 @@ internal class ObjectConfigurationProvider : ConfigurationProviderBase
 
             var itemKey =
                 getKey.Invoke(item, _noArgs)
-                ?? throw new InvalidOperationException(
-                    $"Dictionary key is null at path: {string.Join('.', prefix)}"
-                );
+                ?? throw new InvalidOperationException($"Dictionary key is null at path: {string.Join('.', prefix)}");
             var keyText =
                 itemKey.ToString()
                 ?? throw new InvalidOperationException(

--- a/base/Configuration/src/Annium.Configuration.Abstractions/RemoteConfigurationSourceBase.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/RemoteConfigurationSourceBase.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Annium.Configuration.Abstractions;
+
+/// <summary>
+/// Base class for deferred configuration sources that fetch a document from a remote endpoint at
+/// <see cref="LoadAsync"/> time. Honors a per-source timeout via <see cref="HttpClient.Timeout"/>.
+/// </summary>
+public abstract class RemoteConfigurationSourceBase : IConfigurationSource
+{
+    /// <summary>Default timeout when none is supplied at registration.</summary>
+    public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>The URI to fetch.</summary>
+    private readonly Uri _uri;
+
+    /// <summary>Maximum time before the HTTP call is aborted.</summary>
+    private readonly TimeSpan _timeout;
+
+    /// <summary>Whether a fetch failure (non-2xx, network error, timeout) is silenced.</summary>
+    public bool Optional { get; }
+
+    /// <summary>Format label used in diagnostic messages (e.g. "Json", "Yaml").</summary>
+    protected abstract string FormatLabel { get; }
+
+    /// <summary>
+    /// Parses the fetched payload into the flattened configuration dictionary.
+    /// </summary>
+    /// <param name="raw">Raw payload returned by the remote endpoint.</param>
+    /// <returns>Flattened configuration data.</returns>
+    protected abstract IReadOnlyDictionary<string[], string> ParseRaw(string raw);
+
+    /// <summary>Initializes a new instance of <see cref="RemoteConfigurationSourceBase"/>.</summary>
+    /// <param name="uri">URI to fetch the configuration from.</param>
+    /// <param name="optional">Whether fetch failures are silenced.</param>
+    /// <param name="timeout">Per-source timeout; defaults to <see cref="DefaultTimeout"/> when null.</param>
+    protected RemoteConfigurationSourceBase(Uri uri, bool optional, TimeSpan? timeout)
+    {
+        _uri = uri;
+        _timeout = timeout ?? DefaultTimeout;
+        Optional = optional;
+    }
+
+    /// <summary>
+    /// Issues a GET to the configured URI and flattens the response. Translates
+    /// <see cref="TaskCanceledException"/> to <see cref="TimeoutException"/> when the per-source
+    /// timeout is the cancellation cause, so the caller can distinguish.
+    /// </summary>
+    /// <param name="ct">Cancellation token forwarded by <c>BuildAsync</c>.</param>
+    /// <returns>Flattened configuration.</returns>
+    public async ValueTask<IReadOnlyDictionary<string[], string>> LoadAsync(CancellationToken ct)
+    {
+        using var client = new HttpClient { Timeout = _timeout };
+        try
+        {
+            using var response = await client.GetAsync(_uri, ct);
+            if (!response.IsSuccessStatusCode)
+                throw new HttpRequestException(
+                    $"{FormatLabel} configuration not available at {_uri} ({(int)response.StatusCode} {response.ReasonPhrase})"
+                );
+
+            var raw = await response.Content.ReadAsStringAsync(ct);
+            return ParseRaw(raw);
+        }
+        catch (Exception ex) when (!ct.IsCancellationRequested && IsTimeout(ex))
+        {
+            throw new TimeoutException($"{FormatLabel} configuration fetch from {_uri} exceeded {_timeout}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Recognises a <c>HttpClient.Timeout</c>-induced failure regardless of how the runtime
+    /// wraps it (raw <see cref="TaskCanceledException"/>, or <see cref="HttpRequestException"/>
+    /// with a <see cref="TimeoutException"/> inner).
+    /// </summary>
+    /// <param name="ex">Exception to inspect</param>
+    /// <returns>True when the exception denotes a timeout</returns>
+    private static bool IsTimeout(Exception ex) =>
+        ex is TaskCanceledException
+        || ex is TimeoutException
+        || (ex is HttpRequestException && ex.InnerException is TimeoutException);
+}

--- a/base/Configuration/src/Annium.Configuration.Abstractions/RemoteConfigurationSourceBase.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/RemoteConfigurationSourceBase.cs
@@ -8,12 +8,21 @@ namespace Annium.Configuration.Abstractions;
 
 /// <summary>
 /// Base class for deferred configuration sources that fetch a document from a remote endpoint at
-/// <see cref="LoadAsync"/> time. Honors a per-source timeout via <see cref="HttpClient.Timeout"/>.
+/// <see cref="LoadAsync"/> time. Honors a per-source timeout via a per-call linked
+/// <see cref="CancellationTokenSource"/> (<see cref="CancellationTokenSource.CancelAfter(TimeSpan)"/>);
+/// the shared client runs with <see cref="Timeout.InfiniteTimeSpan"/>.
 /// </summary>
 public abstract class RemoteConfigurationSourceBase : IConfigurationSource
 {
     /// <summary>Default timeout when none is supplied at registration.</summary>
     public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Shared client for every remote source. Its own <see cref="HttpClient.Timeout"/> is disabled
+    /// (infinite); the per-source timeout is enforced via a linked <see cref="CancellationTokenSource"/>
+    /// in <see cref="LoadAsync"/>. A single client avoids the socket exhaustion of per-call instances.
+    /// </summary>
+    private static readonly HttpClient _client = new() { Timeout = Timeout.InfiniteTimeSpan };
 
     /// <summary>The URI to fetch.</summary>
     private readonly Uri _uri;
@@ -54,16 +63,17 @@ public abstract class RemoteConfigurationSourceBase : IConfigurationSource
     /// <returns>Flattened configuration.</returns>
     public async ValueTask<IReadOnlyDictionary<string[], string>> LoadAsync(CancellationToken ct)
     {
-        using var client = new HttpClient { Timeout = _timeout };
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(_timeout);
         try
         {
-            using var response = await client.GetAsync(_uri, ct);
+            using var response = await _client.GetAsync(_uri, cts.Token);
             if (!response.IsSuccessStatusCode)
                 throw new HttpRequestException(
                     $"{FormatLabel} configuration not available at {_uri} ({(int)response.StatusCode} {response.ReasonPhrase})"
                 );
 
-            var raw = await response.Content.ReadAsStringAsync(ct);
+            var raw = await response.Content.ReadAsStringAsync(cts.Token);
             return ParseRaw(raw);
         }
         catch (Exception ex) when (!ct.IsCancellationRequested && IsTimeout(ex))
@@ -73,14 +83,11 @@ public abstract class RemoteConfigurationSourceBase : IConfigurationSource
     }
 
     /// <summary>
-    /// Recognises a <c>HttpClient.Timeout</c>-induced failure regardless of how the runtime
-    /// wraps it (raw <see cref="TaskCanceledException"/>, or <see cref="HttpRequestException"/>
-    /// with a <see cref="TimeoutException"/> inner).
+    /// Recognises a timeout-induced cancellation. The caller-token guard on the catch filter has
+    /// already excluded caller cancellation, so the only cancellation that can reach here is the
+    /// per-source <see cref="CancellationTokenSource.CancelAfter(TimeSpan)"/> firing.
     /// </summary>
     /// <param name="ex">Exception to inspect</param>
     /// <returns>True when the exception denotes a timeout</returns>
-    private static bool IsTimeout(Exception ex) =>
-        ex is TaskCanceledException
-        || ex is TimeoutException
-        || (ex is HttpRequestException && ex.InnerException is TimeoutException);
+    private static bool IsTimeout(Exception ex) => ex is OperationCanceledException;
 }

--- a/base/Configuration/src/Annium.Configuration.Abstractions/ServiceContainerExtensions.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/ServiceContainerExtensions.cs
@@ -123,7 +123,7 @@ public static class ServiceContainerExtensions
     private static void Register(IServiceContainer container, Type type, PropertyInfo property)
     {
         var propertyType = property.PropertyType;
-        container.Add(propertyType, sp => property.GetValue(sp.Resolve(type))!).AsSelf().Singleton();
+        container.Add(propertyType, sp => property.GetValue(sp.Resolve(type)).NotNull()).AsSelf().Singleton();
 
         foreach (var prop in GetRegisteredProperties(propertyType))
             Register(container, propertyType, prop);

--- a/base/Configuration/src/Annium.Configuration.Abstractions/ServiceContainerExtensions.cs
+++ b/base/Configuration/src/Annium.Configuration.Abstractions/ServiceContainerExtensions.cs
@@ -104,29 +104,38 @@ public static class ServiceContainerExtensions
     }
 
     /// <summary>
-    /// Registers all nested properties of the specified type in the service container
+    /// Registers all nested properties of the specified type in the service container.
+    /// Uses a visited-set to prevent infinite recursion on self-referential or
+    /// mutually-referential config types (which would otherwise StackOverflow).
     /// </summary>
     /// <param name="container">The service container</param>
     /// <param name="type">The type to register properties for</param>
     private static void Register(IServiceContainer container, Type type)
     {
+        var visited = new HashSet<Type> { type };
         foreach (var property in GetRegisteredProperties(type))
-            Register(container, type, property);
+            Register(container, type, property, visited);
     }
 
     /// <summary>
-    /// Registers a specific property of a type in the service container
+    /// Registers a specific property of a type in the service container, recursing into
+    /// nested non-collection reference-type properties guarded by <paramref name="visited"/>.
     /// </summary>
     /// <param name="container">The service container</param>
     /// <param name="type">The type containing the property</param>
     /// <param name="property">The property to register</param>
-    private static void Register(IServiceContainer container, Type type, PropertyInfo property)
+    /// <param name="visited">Set of property types already registered in this recursion — prevents cycles.</param>
+    private static void Register(IServiceContainer container, Type type, PropertyInfo property, HashSet<Type> visited)
     {
         var propertyType = property.PropertyType;
+        // Skip cycle: a property of an already-registered type would recurse forever.
+        if (!visited.Add(propertyType))
+            return;
+
         container.Add(propertyType, sp => property.GetValue(sp.Resolve(type)).NotNull()).AsSelf().Singleton();
 
         foreach (var prop in GetRegisteredProperties(propertyType))
-            Register(container, propertyType, prop);
+            Register(container, propertyType, prop, visited);
     }
 
     /// <summary>

--- a/base/Configuration/src/Annium.Configuration.CommandLine/Internal/CommandLineConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.CommandLine/Internal/CommandLineConfigurationProvider.cs
@@ -17,6 +17,11 @@ internal class CommandLineConfigurationProvider : ConfigurationProviderBase
     private const string Separator = "|";
 
     /// <summary>
+    /// Sentinel for "no following argument" used when the current argument is the last one.
+    /// </summary>
+    private const string NoNextArg = "";
+
+    /// <summary>
     /// Command line arguments to process
     /// </summary>
     private readonly string[] _args;
@@ -49,7 +54,7 @@ internal class CommandLineConfigurationProvider : ConfigurationProviderBase
                 continue;
 
             var name = ParseName(value);
-            var next = i < _args.Length - 1 ? _args[i + 1] : string.Empty;
+            var next = i < _args.Length - 1 ? _args[i + 1] : NoNextArg;
 
             if (IsOption(value, next))
             {
@@ -104,7 +109,7 @@ internal class CommandLineConfigurationProvider : ConfigurationProviderBase
     /// <param name="next">Next value in arguments</param>
     /// <returns>True if option with value, false otherwise</returns>
     private bool IsOption(string value, string next) =>
-        IsOptionLike(value) && next != string.Empty && !IsOptionLike(next);
+        IsOptionLike(value) && next != NoNextArg && !IsOptionLike(next);
 
     /// <summary>
     /// Determines if a value is a flag without a following value
@@ -113,7 +118,7 @@ internal class CommandLineConfigurationProvider : ConfigurationProviderBase
     /// <param name="next">Next value in arguments</param>
     /// <returns>True if flag, false otherwise</returns>
     private bool IsFlag(string value, string next) =>
-        IsOptionLike(value) && (next == string.Empty || IsOptionLike(next));
+        IsOptionLike(value) && (next == NoNextArg || IsOptionLike(next));
 
     /// <summary>
     /// Determines if a value looks like an option or flag (starts with -)

--- a/base/Configuration/src/Annium.Configuration.CommandLine/Internal/CommandLineConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.CommandLine/Internal/CommandLineConfigurationProvider.cs
@@ -108,8 +108,7 @@ internal class CommandLineConfigurationProvider : ConfigurationProviderBase
     /// <param name="value">Current value to check</param>
     /// <param name="next">Next value in arguments</param>
     /// <returns>True if option with value, false otherwise</returns>
-    private bool IsOption(string value, string next) =>
-        IsOptionLike(value) && next != NoNextArg && !IsOptionLike(next);
+    private bool IsOption(string value, string next) => IsOptionLike(value) && next != NoNextArg && !IsOptionLike(next);
 
     /// <summary>
     /// Determines if a value is a flag without a following value
@@ -117,8 +116,7 @@ internal class CommandLineConfigurationProvider : ConfigurationProviderBase
     /// <param name="value">Current value to check</param>
     /// <param name="next">Next value in arguments</param>
     /// <returns>True if flag, false otherwise</returns>
-    private bool IsFlag(string value, string next) =>
-        IsOptionLike(value) && (next == NoNextArg || IsOptionLike(next));
+    private bool IsFlag(string value, string next) => IsOptionLike(value) && (next == NoNextArg || IsOptionLike(next));
 
     /// <summary>
     /// Determines if a value looks like an option or flag (starts with -)

--- a/base/Configuration/src/Annium.Configuration.CommandLine/Internal/CommandLineConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.CommandLine/Internal/CommandLineConfigurationProvider.cs
@@ -67,27 +67,27 @@ internal class CommandLineConfigurationProvider : ConfigurationProviderBase
             }
             else if (IsFlag(value, next))
                 if (flags.Contains(name))
-                    throw new Exception($"Same flag '{value}' is used twice");
+                    throw new InvalidOperationException($"Same flag '{value}' is used twice");
                 else
                     flags.Add(name);
             else
-                throw new Exception($"Can't process value '{value}', followed by '{next}'");
+                throw new InvalidOperationException($"Can't process value '{value}', followed by '{next}'");
         }
 
         foreach (var name in flags)
-            Data[name.Split(Separator)] = true.ToString();
+            SetAt(name.Split(Separator), true.ToString());
 
         foreach (var (name, value) in options)
-            Data[name.Split(Separator)] = value;
+            SetAt(name.Split(Separator), value);
 
         foreach (var (name, values) in multiOptions)
         {
             var path = name.Split(Separator);
             for (var i = 0; i < values.Count; i++)
-                Data[path.Append(i.ToString()).ToArray()] = values[i];
+                SetAt(path.Append(i.ToString()).ToArray(), values[i]);
         }
 
-        return Data;
+        return Result;
     }
 
     /// <summary>

--- a/base/Configuration/src/Annium.Configuration.Json/Internal/JsonConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.Json/Internal/JsonConfigurationProvider.cs
@@ -35,7 +35,7 @@ internal class JsonConfigurationProvider : ConfigurationProviderBase
 
         Process(doc.RootElement);
 
-        return Data;
+        return Result;
     }
 
     /// <summary>
@@ -46,9 +46,9 @@ internal class JsonConfigurationProvider : ConfigurationProviderBase
     {
         foreach (var property in token.EnumerateObject())
         {
-            Context.Push(property.Name);
+            Push(property.Name);
             Process(property.Value);
-            Context.Pop();
+            Pop();
         }
     }
 
@@ -61,9 +61,9 @@ internal class JsonConfigurationProvider : ConfigurationProviderBase
         var index = 0;
         foreach (var item in token.EnumerateArray())
         {
-            Context.Push(index.ToString());
+            Push(index.ToString());
             Process(item);
-            Context.Pop();
+            Pop();
             index++;
         }
     }
@@ -74,7 +74,7 @@ internal class JsonConfigurationProvider : ConfigurationProviderBase
     /// <param name="token">JSON element representing a leaf value</param>
     private void ProcessLeaf(JsonElement token)
     {
-        Data[Path] = token.ToString();
+        Set(token.ToString());
     }
 
     /// <summary>

--- a/base/Configuration/src/Annium.Configuration.Json/Internal/JsonFileSource.cs
+++ b/base/Configuration/src/Annium.Configuration.Json/Internal/JsonFileSource.cs
@@ -1,40 +1,20 @@
 using System.Collections.Generic;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 using Annium.Configuration.Abstractions;
 
 namespace Annium.Configuration.Json.Internal;
 
 /// <summary>
-/// Deferred configuration source that reads a JSON file at <see cref="LoadAsync"/> time.
+/// Deferred configuration source that reads a JSON file at <see cref="FileConfigurationSourceBase.LoadAsync"/> time.
 /// </summary>
-internal sealed class JsonFileSource : IConfigurationSource
+internal sealed class JsonFileSource : FileConfigurationSourceBase
 {
-    /// <summary>Absolute path to the JSON file.</summary>
-    private readonly string _path;
-
-    /// <summary>Whether a missing/unreadable file is silenced.</summary>
-    public bool Optional { get; }
+    /// <inheritdoc />
+    protected override string FormatLabel => "Json";
 
     public JsonFileSource(string path, bool optional)
-    {
-        _path = Path.GetFullPath(path);
-        Optional = optional;
-    }
+        : base(path, optional) { }
 
-    /// <summary>
-    /// Reads the JSON file and flattens it. Throws <see cref="FileNotFoundException"/> when the
-    /// file is absent (caller decides whether to swallow via <see cref="IConfigurationSource.Optional"/>).
-    /// </summary>
-    /// <param name="ct">Cancellation token forwarded to the file read.</param>
-    /// <returns>Flattened JSON configuration.</returns>
-    public async ValueTask<IReadOnlyDictionary<string[], string>> LoadAsync(CancellationToken ct)
-    {
-        if (!File.Exists(_path))
-            throw new FileNotFoundException($"Json configuration file {_path} not found and is not optional", _path);
-
-        var raw = await File.ReadAllTextAsync(_path, ct);
-        return new JsonConfigurationProvider(raw).Read();
-    }
+    /// <inheritdoc />
+    protected override IReadOnlyDictionary<string[], string> ParseRaw(string raw) =>
+        new JsonConfigurationProvider(raw).Read();
 }

--- a/base/Configuration/src/Annium.Configuration.Json/Internal/JsonRemoteSource.cs
+++ b/base/Configuration/src/Annium.Configuration.Json/Internal/JsonRemoteSource.cs
@@ -1,73 +1,22 @@
 using System;
 using System.Collections.Generic;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Annium.Configuration.Abstractions;
 
 namespace Annium.Configuration.Json.Internal;
 
 /// <summary>
 /// Deferred configuration source that fetches a JSON document from a remote endpoint at
-/// <see cref="LoadAsync"/> time. Honors a per-source timeout via <see cref="HttpClient.Timeout"/>.
+/// <see cref="RemoteConfigurationSourceBase.LoadAsync"/> time.
 /// </summary>
-internal sealed class JsonRemoteSource : IConfigurationSource
+internal sealed class JsonRemoteSource : RemoteConfigurationSourceBase
 {
-    /// <summary>Default timeout when none is supplied at registration.</summary>
-    internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
-
-    /// <summary>The URI to fetch.</summary>
-    private readonly Uri _uri;
-
-    /// <summary>Maximum time before the HTTP call is aborted.</summary>
-    private readonly TimeSpan _timeout;
-
-    /// <summary>Whether a fetch failure (non-2xx, network error, timeout) is silenced.</summary>
-    public bool Optional { get; }
+    /// <inheritdoc />
+    protected override string FormatLabel => "Json";
 
     public JsonRemoteSource(Uri uri, bool optional, TimeSpan? timeout)
-    {
-        _uri = uri;
-        _timeout = timeout ?? DefaultTimeout;
-        Optional = optional;
-    }
+        : base(uri, optional, timeout) { }
 
-    /// <summary>
-    /// Issues a GET to the configured URI and flattens the JSON response. Translates
-    /// <see cref="TaskCanceledException"/> to <see cref="TimeoutException"/> when the per-source
-    /// timeout is the cancellation cause, so the caller can distinguish.
-    /// </summary>
-    /// <param name="ct">Cancellation token forwarded by <c>BuildAsync</c>.</param>
-    /// <returns>Flattened JSON configuration.</returns>
-    public async ValueTask<IReadOnlyDictionary<string[], string>> LoadAsync(CancellationToken ct)
-    {
-        using var client = new HttpClient { Timeout = _timeout };
-        try
-        {
-            using var response = await client.GetAsync(_uri, ct);
-            if (!response.IsSuccessStatusCode)
-                throw new HttpRequestException(
-                    $"Json configuration not available at {_uri} ({(int)response.StatusCode} {response.ReasonPhrase})"
-                );
-
-            var raw = await response.Content.ReadAsStringAsync(ct);
-            return new JsonConfigurationProvider(raw).Read();
-        }
-        catch (Exception ex) when (!ct.IsCancellationRequested && IsTimeout(ex))
-        {
-            throw new TimeoutException($"Json configuration fetch from {_uri} exceeded {_timeout}", ex);
-        }
-    }
-
-    /// <summary>
-    /// Recognises a <c>HttpClient.Timeout</c>-induced failure regardless of how the runtime
-    /// wraps it (raw <see cref="TaskCanceledException"/>, or <see cref="HttpRequestException"/>
-    /// with a <see cref="TimeoutException"/> inner).
-    /// </summary>
-    /// <param name="ex">Exception to inspect</param>
-    /// <returns>True when the exception denotes a timeout</returns>
-    private static bool IsTimeout(Exception ex) =>
-        ex is TaskCanceledException
-        || ex is TimeoutException
-        || (ex is HttpRequestException && ex.InnerException is TimeoutException);
+    /// <inheritdoc />
+    protected override IReadOnlyDictionary<string[], string> ParseRaw(string raw) =>
+        new JsonConfigurationProvider(raw).Read();
 }

--- a/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlConfigurationProvider.cs
@@ -62,9 +62,7 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
                 throw new InvalidOperationException($"YAML mapping key must be a scalar, got {key.GetType().Name}");
 
             if (scalarKey.Value is null)
-                throw new InvalidOperationException(
-                    $"YAML mapping key cannot be null at path: {PathString}"
-                );
+                throw new InvalidOperationException($"YAML mapping key cannot be null at path: {PathString}");
 
             Push(scalarKey.Value);
 
@@ -101,9 +99,7 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
             else if (item is YamlScalarNode scalarItem)
                 Process(scalarItem);
             else
-                throw new InvalidOperationException(
-                    $"Unexpected YAML node type {item.GetType().Name} at {PathString}"
-                );
+                throw new InvalidOperationException($"Unexpected YAML node type {item.GetType().Name} at {PathString}");
 
             Pop();
             index++;

--- a/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlConfigurationProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Annium.Configuration.Abstractions;
@@ -39,7 +40,12 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
         if (stream.Documents.Count == 0)
             return Data;
 
-        Process((YamlMappingNode)stream.Documents[0].RootNode);
+        if (stream.Documents[0].RootNode is not YamlMappingNode root)
+            throw new InvalidOperationException(
+                $"YAML root must be a mapping node, got {stream.Documents[0].RootNode.GetType().Name}"
+            );
+
+        Process(root);
 
         return Data;
     }
@@ -52,14 +58,23 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
     {
         foreach (var (key, value) in node.Children)
         {
-            Context.Push(((YamlScalarNode)key).Value!);
+            if (key is not YamlScalarNode scalarKey)
+                throw new InvalidOperationException(
+                    $"YAML mapping key must be a scalar, got {key.GetType().Name}"
+                );
+
+            Context.Push(scalarKey.Value!);
 
             if (value is YamlMappingNode map)
                 Process(map);
             else if (value is YamlSequenceNode seq)
                 Process(seq);
+            else if (value is YamlScalarNode scalarValue)
+                Process(scalarValue);
             else
-                Process((YamlScalarNode)value);
+                throw new InvalidOperationException(
+                    $"Unexpected YAML node type {value.GetType().Name} at {string.Join(".", Path)}"
+                );
 
             Context.Pop();
         }
@@ -80,8 +95,12 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
                 Process(map);
             else if (item is YamlSequenceNode seq)
                 Process(seq);
+            else if (item is YamlScalarNode scalarItem)
+                Process(scalarItem);
             else
-                Process((YamlScalarNode)item);
+                throw new InvalidOperationException(
+                    $"Unexpected YAML node type {item.GetType().Name} at {string.Join(".", Path)}"
+                );
 
             Context.Pop();
             index++;

--- a/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlConfigurationProvider.cs
@@ -63,7 +63,7 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
 
             if (scalarKey.Value is null)
                 throw new InvalidOperationException(
-                    $"YAML mapping key cannot be null at path: {string.Join('.', Path)}"
+                    $"YAML mapping key cannot be null at path: {PathString}"
                 );
 
             Push(scalarKey.Value);
@@ -76,7 +76,7 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
                 Process(scalarValue);
             else
                 throw new InvalidOperationException(
-                    $"Unexpected YAML node type {value.GetType().Name} at {string.Join('.', Path)}"
+                    $"Unexpected YAML node type {value.GetType().Name} at {PathString}"
                 );
 
             Pop();
@@ -102,7 +102,7 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
                 Process(scalarItem);
             else
                 throw new InvalidOperationException(
-                    $"Unexpected YAML node type {item.GetType().Name} at {string.Join('.', Path)}"
+                    $"Unexpected YAML node type {item.GetType().Name} at {PathString}"
                 );
 
             Pop();

--- a/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlConfigurationProvider.cs
@@ -63,7 +63,12 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
                     $"YAML mapping key must be a scalar, got {key.GetType().Name}"
                 );
 
-            Context.Push(scalarKey.Value!);
+            if (scalarKey.Value is null)
+                throw new InvalidOperationException(
+                    $"YAML mapping key cannot be null at path: {string.Join('.', Path)}"
+                );
+
+            Context.Push(scalarKey.Value);
 
             if (value is YamlMappingNode map)
                 Process(map);
@@ -108,11 +113,22 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
     }
 
     /// <summary>
-    /// Processes a YAML scalar node by adding its value to the configuration data
+    /// Processes a YAML scalar node by adding its value to the configuration data.
     /// </summary>
-    /// <param name="token">YAML scalar node to process</param>
+    /// <param name="token">YAML scalar node to process.</param>
+    /// <remarks>
+    /// <see cref="YamlScalarNode.Value"/> is declared <c>string?</c>. Under default YamlDotNet
+    /// parsing of well-formed input it is never null (e.g. <c>key: ~</c> produces <c>Value = "~"</c>,
+    /// not <c>null</c>); a null only arises from an uninitialized / programmatically constructed
+    /// scalar. This defensive guard silently skips that state so the entry is absent from the
+    /// resulting configuration rather than crashing with NRE downstream. A null mapping KEY (see
+    /// <see cref="Process(YamlMappingNode)"/>) is treated differently — a null key cannot be
+    /// encoded into the configuration path and throws.
+    /// </remarks>
     private void Process(YamlScalarNode token)
     {
-        Data[Path] = token.Value!;
+        if (token.Value is null)
+            return;
+        Data[Path] = token.Value;
     }
 }

--- a/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlConfigurationProvider.cs
@@ -38,7 +38,7 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
         stream.Load(reader);
 
         if (stream.Documents.Count == 0)
-            return Data;
+            return Result;
 
         if (stream.Documents[0].RootNode is not YamlMappingNode root)
             throw new InvalidOperationException(
@@ -47,7 +47,7 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
 
         Process(root);
 
-        return Data;
+        return Result;
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
                     $"YAML mapping key cannot be null at path: {string.Join('.', Path)}"
                 );
 
-            Context.Push(scalarKey.Value);
+            Push(scalarKey.Value);
 
             if (value is YamlMappingNode map)
                 Process(map);
@@ -76,10 +76,10 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
                 Process(scalarValue);
             else
                 throw new InvalidOperationException(
-                    $"Unexpected YAML node type {value.GetType().Name} at {string.Join(".", Path)}"
+                    $"Unexpected YAML node type {value.GetType().Name} at {string.Join('.', Path)}"
                 );
 
-            Context.Pop();
+            Pop();
         }
     }
 
@@ -92,7 +92,7 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
         var index = 0;
         foreach (var item in node)
         {
-            Context.Push(index.ToString());
+            Push(index.ToString());
 
             if (item is YamlMappingNode map)
                 Process(map);
@@ -102,10 +102,10 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
                 Process(scalarItem);
             else
                 throw new InvalidOperationException(
-                    $"Unexpected YAML node type {item.GetType().Name} at {string.Join(".", Path)}"
+                    $"Unexpected YAML node type {item.GetType().Name} at {string.Join('.', Path)}"
                 );
 
-            Context.Pop();
+            Pop();
             index++;
         }
     }
@@ -127,6 +127,6 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
     {
         if (token.Value is null)
             return;
-        Data[Path] = token.Value;
+        Set(token.Value);
     }
 }

--- a/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlConfigurationProvider.cs
+++ b/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlConfigurationProvider.cs
@@ -59,9 +59,7 @@ internal class YamlConfigurationProvider : ConfigurationProviderBase
         foreach (var (key, value) in node.Children)
         {
             if (key is not YamlScalarNode scalarKey)
-                throw new InvalidOperationException(
-                    $"YAML mapping key must be a scalar, got {key.GetType().Name}"
-                );
+                throw new InvalidOperationException($"YAML mapping key must be a scalar, got {key.GetType().Name}");
 
             if (scalarKey.Value is null)
                 throw new InvalidOperationException(

--- a/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlFileSource.cs
+++ b/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlFileSource.cs
@@ -1,40 +1,20 @@
 using System.Collections.Generic;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 using Annium.Configuration.Abstractions;
 
 namespace Annium.Configuration.Yaml.Internal;
 
 /// <summary>
-/// Deferred configuration source that reads a YAML file at <see cref="LoadAsync"/> time.
+/// Deferred configuration source that reads a YAML file at <see cref="FileConfigurationSourceBase.LoadAsync"/> time.
 /// </summary>
-internal sealed class YamlFileSource : IConfigurationSource
+internal sealed class YamlFileSource : FileConfigurationSourceBase
 {
-    /// <summary>Absolute path to the YAML file.</summary>
-    private readonly string _path;
-
-    /// <summary>Whether a missing/unreadable file is silenced.</summary>
-    public bool Optional { get; }
+    /// <inheritdoc />
+    protected override string FormatLabel => "Yaml";
 
     public YamlFileSource(string path, bool optional)
-    {
-        _path = Path.GetFullPath(path);
-        Optional = optional;
-    }
+        : base(path, optional) { }
 
-    /// <summary>
-    /// Reads the YAML file and flattens it. Throws <see cref="FileNotFoundException"/> when the
-    /// file is absent (caller decides whether to swallow via <see cref="IConfigurationSource.Optional"/>).
-    /// </summary>
-    /// <param name="ct">Cancellation token forwarded to the file read.</param>
-    /// <returns>Flattened YAML configuration.</returns>
-    public async ValueTask<IReadOnlyDictionary<string[], string>> LoadAsync(CancellationToken ct)
-    {
-        if (!File.Exists(_path))
-            throw new FileNotFoundException($"Yaml configuration file {_path} not found and is not optional", _path);
-
-        var raw = await File.ReadAllTextAsync(_path, ct);
-        return new YamlConfigurationProvider(raw).Read();
-    }
+    /// <inheritdoc />
+    protected override IReadOnlyDictionary<string[], string> ParseRaw(string raw) =>
+        new YamlConfigurationProvider(raw).Read();
 }

--- a/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlRemoteSource.cs
+++ b/base/Configuration/src/Annium.Configuration.Yaml/Internal/YamlRemoteSource.cs
@@ -1,73 +1,22 @@
 using System;
 using System.Collections.Generic;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Annium.Configuration.Abstractions;
 
 namespace Annium.Configuration.Yaml.Internal;
 
 /// <summary>
 /// Deferred configuration source that fetches a YAML document from a remote endpoint at
-/// <see cref="LoadAsync"/> time. Honors a per-source timeout via <see cref="HttpClient.Timeout"/>.
+/// <see cref="RemoteConfigurationSourceBase.LoadAsync"/> time.
 /// </summary>
-internal sealed class YamlRemoteSource : IConfigurationSource
+internal sealed class YamlRemoteSource : RemoteConfigurationSourceBase
 {
-    /// <summary>Default timeout when none is supplied at registration.</summary>
-    internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
-
-    /// <summary>The URI to fetch.</summary>
-    private readonly Uri _uri;
-
-    /// <summary>Maximum time before the HTTP call is aborted.</summary>
-    private readonly TimeSpan _timeout;
-
-    /// <summary>Whether a fetch failure (non-2xx, network error, timeout) is silenced.</summary>
-    public bool Optional { get; }
+    /// <inheritdoc />
+    protected override string FormatLabel => "Yaml";
 
     public YamlRemoteSource(Uri uri, bool optional, TimeSpan? timeout)
-    {
-        _uri = uri;
-        _timeout = timeout ?? DefaultTimeout;
-        Optional = optional;
-    }
+        : base(uri, optional, timeout) { }
 
-    /// <summary>
-    /// Issues a GET to the configured URI and flattens the YAML response. Translates
-    /// <see cref="TaskCanceledException"/> to <see cref="TimeoutException"/> when the per-source
-    /// timeout is the cancellation cause, so the caller can distinguish.
-    /// </summary>
-    /// <param name="ct">Cancellation token forwarded by <c>BuildAsync</c>.</param>
-    /// <returns>Flattened YAML configuration.</returns>
-    public async ValueTask<IReadOnlyDictionary<string[], string>> LoadAsync(CancellationToken ct)
-    {
-        using var client = new HttpClient { Timeout = _timeout };
-        try
-        {
-            using var response = await client.GetAsync(_uri, ct);
-            if (!response.IsSuccessStatusCode)
-                throw new HttpRequestException(
-                    $"Yaml configuration not available at {_uri} ({(int)response.StatusCode} {response.ReasonPhrase})"
-                );
-
-            var raw = await response.Content.ReadAsStringAsync(ct);
-            return new YamlConfigurationProvider(raw).Read();
-        }
-        catch (Exception ex) when (!ct.IsCancellationRequested && IsTimeout(ex))
-        {
-            throw new TimeoutException($"Yaml configuration fetch from {_uri} exceeded {_timeout}", ex);
-        }
-    }
-
-    /// <summary>
-    /// Recognises a <c>HttpClient.Timeout</c>-induced failure regardless of how the runtime
-    /// wraps it (raw <see cref="TaskCanceledException"/>, or <see cref="HttpRequestException"/>
-    /// with a <see cref="TimeoutException"/> inner).
-    /// </summary>
-    /// <param name="ex">Exception to inspect</param>
-    /// <returns>True when the exception denotes a timeout</returns>
-    private static bool IsTimeout(Exception ex) =>
-        ex is TaskCanceledException
-        || ex is TimeoutException
-        || (ex is HttpRequestException && ex.InnerException is TimeoutException);
+    /// <inheritdoc />
+    protected override IReadOnlyDictionary<string[], string> ParseRaw(string raw) =>
+        new YamlConfigurationProvider(raw).Read();
 }

--- a/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/AddConfigurationAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/AddConfigurationAsyncTests.cs
@@ -1,11 +1,8 @@
 using System;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Annium.Configuration.Tests.Lib;
 using Annium.Core.DependencyInjection;
-using Annium.Core.Mapper;
-using Annium.Core.Runtime;
-using Annium.Logging.Shared;
 using Annium.Testing;
 using Xunit;
 
@@ -33,20 +30,7 @@ public class AddConfigurationAsyncTests
         public int Plain { get; set; }
     }
 
-    /// <summary>
-    /// Builds an isolated <see cref="IServiceProvider"/> that has the minimum registrations
-    /// required for <c>AddConfigurationAsync</c> to succeed:
-    /// runtime type scanning (for <c>ITypeManager</c>) and the mapper (for <c>IMapper</c>).
-    /// </summary>
-    private static ServiceContainer CreateContainer()
-    {
-        var container = new ServiceContainer();
-        container.AddRuntime(Assembly.GetExecutingAssembly());
-        container.AddTime().WithRealTime().SetDefault();
-        container.AddLogging();
-        container.AddMapper(autoload: false);
-        return container;
-    }
+    private static ServiceContainer CreateContainer() => TestContainerFactory.Create();
 
     // ---------------------------------------------------------------------------
     // Test 1 — sync ergonomic overload resolves the registered value

--- a/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/BuildAsyncMergeOrderTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/BuildAsyncMergeOrderTests.cs
@@ -99,6 +99,24 @@ public class BuildAsyncMergeOrderTests
     }
 
     /// <summary>
+    /// An optional source that observes a pre-cancelled token must NOT swallow the caller's
+    /// cancellation: <c>BuildAsync</c> propagates <see cref="OperationCanceledException"/> directly,
+    /// regardless of the source's <c>Optional</c> flag. Locks in the optional-source branch of the
+    /// <c>catch (OperationCanceledException) when (ct.IsCancellationRequested)</c> guard.
+    /// </summary>
+    [Fact]
+    public async Task BuildAsync_OptionalSourcePrecancelledCt_ThrowsOperationCanceledException()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var container = ConfigurationFactory.CreateContainer();
+        container.AddSource(new CancelObservingSource(optional: true));
+
+        await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<OperationCanceledException>();
+    }
+
+    /// <summary>
     /// In-memory source returning a fixed dictionary on <c>LoadAsync</c>.
     /// </summary>
     private sealed class StubSource : IConfigurationSource
@@ -135,5 +153,27 @@ public class BuildAsyncMergeOrderTests
         public bool Optional { get; }
 
         public ValueTask<IReadOnlyDictionary<string[], string>> LoadAsync(CancellationToken ct) => throw _ex;
+    }
+
+    /// <summary>
+    /// Source that honors the cancellation token on <c>LoadAsync</c> — used to verify that
+    /// caller cancellation propagates even when the source is optional.
+    /// </summary>
+    private sealed class CancelObservingSource : IConfigurationSource
+    {
+        private static readonly IReadOnlyDictionary<string[], string> _empty = new Dictionary<string[], string>();
+
+        public CancelObservingSource(bool optional)
+        {
+            Optional = optional;
+        }
+
+        public bool Optional { get; }
+
+        public ValueTask<IReadOnlyDictionary<string[], string>> LoadAsync(CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            return new(_empty);
+        }
     }
 }

--- a/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/BuildAsyncMergeOrderTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/BuildAsyncMergeOrderTests.cs
@@ -83,6 +83,22 @@ public class BuildAsyncMergeOrderTests
     }
 
     /// <summary>
+    /// When every source is optional and every one throws, <c>BuildAsync</c> raises no exception
+    /// (the non-optional failure filter yields nothing) and the container is left empty.
+    /// </summary>
+    [Fact]
+    public async Task BuildAsync_AllSourcesOptionalAndAllFail_SucceedsWithEmptyContainer()
+    {
+        var container = ConfigurationFactory.CreateContainer();
+        container.AddSource(new ThrowingSource(new InvalidOperationException("first down"), optional: true));
+        container.AddSource(new ThrowingSource(new NotSupportedException("second down"), optional: true));
+
+        await container.BuildAsync(TestContext.Current.CancellationToken);
+
+        container.Get().Count.Is(0);
+    }
+
+    /// <summary>
     /// In-memory source returning a fixed dictionary on <c>LoadAsync</c>.
     /// </summary>
     private sealed class StubSource : IConfigurationSource

--- a/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/BuildAsyncMergeOrderTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/BuildAsyncMergeOrderTests.cs
@@ -47,6 +47,25 @@ public class BuildAsyncMergeOrderTests
     }
 
     /// <summary>
+    /// Two non-optional sources that throw distinct exception types aggregate both into the
+    /// resulting <see cref="AggregateException"/>.
+    /// </summary>
+    [Fact]
+    public async Task BuildAsync_TwoNonOptionalFail_AggregateContainsBothErrors()
+    {
+        var container = ConfigurationFactory.CreateContainer();
+        container.AddSource(new ThrowingSource(new InvalidOperationException("first down"), optional: false));
+        container.AddSource(new ThrowingSource(new NotSupportedException("second down"), optional: false));
+
+        var ex = await Wrap.It(async () => await container.BuildAsync(TestContext.Current.CancellationToken))
+            .ThrowsAsync<AggregateException>();
+        ex.InnerExceptions.Has(2);
+        // Order matches Task.WhenAll input order = registration order.
+        ex.InnerExceptions[0].As<InvalidOperationException>();
+        ex.InnerExceptions[1].As<NotSupportedException>();
+    }
+
+    /// <summary>
     /// An optional source that throws is silenced; the surviving source's data lands in the container.
     /// </summary>
     [Fact]

--- a/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/BuildAsyncMergeOrderTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/BuildAsyncMergeOrderTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Annium.Configuration.Abstractions.Internal;
 using Annium.Testing;
 using Xunit;
 
@@ -20,7 +19,7 @@ public class BuildAsyncMergeOrderTests
     [Fact]
     public async Task BuildAsync_TwoSources_MergesInRegistrationOrder()
     {
-        var container = new ConfigurationContainer();
+        var container = ConfigurationFactory.CreateContainer();
         container.AddSource(new StubSource(new[] { (new[] { "key" }, "first") }, optional: false));
         container.AddSource(new StubSource(new[] { (new[] { "key" }, "second") }, optional: false));
 
@@ -37,7 +36,7 @@ public class BuildAsyncMergeOrderTests
     [Fact]
     public async Task BuildAsync_OneNonOptionalFails_ThrowsAggregate()
     {
-        var container = new ConfigurationContainer();
+        var container = ConfigurationFactory.CreateContainer();
         container.AddSource(new StubSource(new[] { (new[] { "ok" }, "v") }, optional: false));
         container.AddSource(new ThrowingSource(new InvalidOperationException("source down"), optional: false));
 
@@ -53,7 +52,7 @@ public class BuildAsyncMergeOrderTests
     [Fact]
     public async Task BuildAsync_OneOptionalFails_OneSucceeds_SucceedsWithSucceededData()
     {
-        var container = new ConfigurationContainer();
+        var container = ConfigurationFactory.CreateContainer();
         container.AddSource(new ThrowingSource(new InvalidOperationException("flaky"), optional: true));
         container.AddSource(new StubSource(new[] { (new[] { "ok" }, "value") }, optional: false));
 

--- a/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ConfigurationProviderBaseTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ConfigurationProviderBaseTests.cs
@@ -1,0 +1,168 @@
+using System.Collections.Generic;
+using System.Linq;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Configuration.Abstractions.Tests;
+
+/// <summary>
+/// Tests covering <see cref="ConfigurationProviderBase"/> protected contract — exercised via
+/// minimal in-file stub subclasses that use every helper
+/// (<c>Init</c>, <c>Push</c>, <c>Pop</c>, <c>Set</c>, <c>SetAt</c>, <c>Path</c>, <c>Result</c>).
+/// </summary>
+public class ConfigurationProviderBaseTests
+{
+    /// <summary>
+    /// Calling <see cref="ConfigurationProviderBase.Read"/> twice on the same instance must
+    /// produce identical, non-accumulated results. <see cref="ConfigurationProviderBase.Result"/>
+    /// returns a snapshot each call, so the first-call dictionary is captured here as a
+    /// snapshot copy and compared against the second-call result — a mutation removing
+    /// <c>_data.Clear()</c> from <c>Init()</c> would cause the second call's count to grow.
+    /// </summary>
+    [Fact]
+    public void Read_CalledTwice_ProducesIdenticalNonAccumulatedResult()
+    {
+        var provider = new BalancedStubProvider();
+
+        var first = provider.Read();
+        // Snapshot first to a list of (path, value) tuples — Result returns a fresh
+        // Dictionary<string[], string> with reference-equality keys, so we match by sequence.
+        var firstSnapshot = first.Select(kv => (Path: kv.Key, Value: kv.Value)).ToList();
+        var second = provider.Read();
+
+        firstSnapshot.Count.Is(4);
+        second.Count.Is(firstSnapshot.Count);
+
+        // Explicit per-path + value assertions (catches Set / SetAt mutations independently).
+        FindByPath(firstSnapshot, "a").Is("v-a");
+        FindByPath(firstSnapshot, "a", "b").Is("v-ab");
+        FindByPath(firstSnapshot, "a", "b", "c").Is("v-abc");
+        FindByPath(firstSnapshot, "absolute", "leaf").Is("v-abs");
+
+        // Second read must contain exactly the same paths + values — not extra entries that
+        // would survive a missing _data.Clear() in Init() (would fail the Count assertion above)
+        // and not different values either.
+        foreach (var (path, value) in firstSnapshot)
+        {
+            var match = second.FirstOrDefault(kv => kv.Key.SequenceEqual(path));
+            match.Key.IsNotDefault();
+            match.Value.Is(value);
+        }
+    }
+
+    /// <summary>Lookup helper: find a value in a (path,value) list by sequence-equal path.</summary>
+    private static string FindByPath(List<(string[] Path, string Value)> snapshot, params string[] path) =>
+        snapshot.First(t => t.Path.SequenceEqual(path)).Value;
+
+    /// <summary>
+    /// Verifies the <c>Push</c> / <c>Pop</c> / <c>Path</c> machinery: after a Push the Path
+    /// extends; after a matching Pop the Path contracts; nested sequences produce the expected
+    /// dotted-path order (FIFO from outermost Push).
+    /// </summary>
+    [Fact]
+    public void PushPop_ContextStack_BuildsPathInOuterToInnerOrder()
+    {
+        var provider = new BalancedStubProvider();
+        provider.Read();
+
+        provider.CapturedPaths.Has(3);
+        provider.CapturedPaths[0].SequenceEqual(new[] { "a" }).IsTrue();
+        provider.CapturedPaths[1].SequenceEqual(new[] { "a", "b" }).IsTrue();
+        provider.CapturedPaths[2].SequenceEqual(new[] { "a", "b", "c" }).IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies that <c>Init()</c> clears the context stack even when a prior <c>Read()</c>
+    /// left segments pushed (e.g. exception mid-read before matching Pop). Without
+    /// <c>_context.Clear()</c> in <c>Init()</c>, the second <c>Read()</c> would observe a
+    /// non-empty <c>Path</c> at its first <c>Push</c> and produce a wrongly-prefixed key.
+    /// </summary>
+    [Fact]
+    public void Init_AfterUnbalancedPush_ClearsContextStack()
+    {
+        var provider = new UnbalancedStubProvider();
+
+        // First Read leaves "stale" on the stack (no matching Pop). Path captured after
+        // Push("stale") + Push("fresh") is ["stale", "fresh"].
+        provider.Read();
+        provider.LastPathSeenInRead.SequenceEqual(new[] { "stale", "fresh" }).IsTrue();
+
+        // Second Read: Init() must clear the stack. If _context.Clear() was removed from
+        // Init(), the leftover "stale" from the first Read would still be present, so
+        // Push("stale") + Push("fresh") would yield ["stale", "stale", "fresh"] —
+        // catching the mutation.
+        provider.Read();
+        provider.LastPathSeenInRead.SequenceEqual(new[] { "stale", "fresh" }).IsTrue();
+        provider.FirstPushPath.SequenceEqual(new[] { "stale" }).IsTrue();
+    }
+
+    /// <summary>
+    /// Minimal subclass exercising every protected helper. Balanced Push/Pop.
+    /// </summary>
+    private sealed class BalancedStubProvider : ConfigurationProviderBase
+    {
+        /// <summary>Snapshots of <see cref="ConfigurationProviderBase.Path"/> captured during Read.</summary>
+        public List<string[]> CapturedPaths { get; } = new();
+
+        /// <inheritdoc />
+        public override IReadOnlyDictionary<string[], string> Read()
+        {
+            Init();
+            CapturedPaths.Clear();
+
+            Push("a");
+            CapturedPaths.Add(Path);
+            Set("v-a");
+
+            Push("b");
+            CapturedPaths.Add(Path);
+            Set("v-ab");
+
+            Push("c");
+            CapturedPaths.Add(Path);
+            Set("v-abc");
+
+            Pop();
+            Pop();
+            Pop();
+
+            SetAt(new[] { "absolute", "leaf" }, "v-abs");
+
+            return Result;
+        }
+    }
+
+    /// <summary>
+    /// Subclass that leaves <c>"stale"</c> on the context stack after its first <c>Read</c>
+    /// (no matching Pop) — used to verify <c>Init()</c> resets the stack on subsequent reads.
+    /// </summary>
+    private sealed class UnbalancedStubProvider : ConfigurationProviderBase
+    {
+        /// <summary>The Path captured immediately after the second Push of the most recent Read.</summary>
+        public string[] LastPathSeenInRead { get; private set; } = System.Array.Empty<string>();
+
+        /// <summary>The Path captured immediately after the first Push of the most recent Read.</summary>
+        public string[] FirstPushPath { get; private set; } = System.Array.Empty<string>();
+
+        /// <inheritdoc />
+        public override IReadOnlyDictionary<string[], string> Read()
+        {
+            Init();
+
+            // Leave "stale" on the stack — caller never sees the matching Pop in this Read.
+            Push("stale");
+            // After the first push the path should be ["stale"] OR — if Init failed to clear
+            // _context — would include whatever was left from a prior Read. Capture
+            // the second push's path (after a fresh Push) and the first push's path on its own.
+            FirstPushPath = Path;
+
+            Push("fresh");
+            LastPathSeenInRead = Path;
+            Set("v-fresh");
+            Pop();
+
+            // Intentionally NO matching Pop for "stale" — Init must clear it on next call.
+            return Result;
+        }
+    }
+}

--- a/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ObjectConfigurationProviderTest.cs
+++ b/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ObjectConfigurationProviderTest.cs
@@ -72,5 +72,7 @@ public class ObjectConfigurationProviderTest : TestBase
         result.Abstract.As<ConfigTwo>().Value.Is(10);
         result.Abstract.IsEqual(nested);
         nested.IsEqual(new ConfigTwo { Value = 10 });
+        result.Tuple.Item1.Is("demo|");
+        result.Tuple.Item2.Is(11);
     }
 }

--- a/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ProcessorEdgeCaseTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ProcessorEdgeCaseTests.cs
@@ -1,12 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Threading.Tasks;
 using Annium.Configuration.Tests.Lib;
 using Annium.Core.DependencyInjection;
-using Annium.Core.Mapper;
-using Annium.Core.Runtime;
-using Annium.Logging.Shared;
 using Annium.Testing;
 using Xunit;
 
@@ -19,19 +15,7 @@ namespace Annium.Configuration.Abstractions.Tests;
 /// </summary>
 public class ProcessorEdgeCaseTests
 {
-    /// <summary>
-    /// Builds a minimal <see cref="ServiceContainer"/> with the registrations
-    /// <c>AddConfigurationAsync</c> needs (runtime types + mapper).
-    /// </summary>
-    private static ServiceContainer CreateContainer()
-    {
-        var container = new ServiceContainer();
-        container.AddRuntime(Assembly.GetExecutingAssembly());
-        container.AddTime().WithRealTime().SetDefault();
-        container.AddLogging();
-        container.AddMapper(autoload: false);
-        return container;
-    }
+    private static ServiceContainer CreateContainer() => TestContainerFactory.Create();
 
     /// <summary>
     /// When configuration data has a non-leaf descendant for a primitive-element list
@@ -157,8 +141,8 @@ public class ProcessorEdgeCaseTests
         await container.AddConfigurationAsync<Config>(cfg => cfg.Add(sentinel), TestContext.Current.CancellationToken);
 
         var resolved = container.BuildServiceProvider().Resolve<Config>();
-        resolved.Nullable.HasValue.IsTrue();
-        resolved.Nullable!.Value.Is(99m);
+        resolved.Nullable.IsNotDefault();
+        resolved.Nullable.Value.Is(99m);
     }
 
     /// <summary>
@@ -180,5 +164,75 @@ public class ProcessorEdgeCaseTests
         var sp = container.BuildServiceProvider();
         sp.Resolve<Config>().Plain.Is(5);
         sp.Resolve<Val>().Plain.Is(3);
+    }
+
+    /// <summary>
+    /// When the resolution key field value does not map to any registered concrete type
+    /// (<c>ResolveByKey</c> returns null), the processor throws <see cref="ArgumentException"/>.
+    /// Exercised via a wrapper type because <c>AddConfigurationAsync&lt;T&gt;</c> requires
+    /// <c>T : new()</c> and abstract types are barred at the entry point.
+    /// </summary>
+    [Fact]
+    public async Task Process_AbstractTypeWithUnknownResolutionKeyValue_ThrowsArgumentException()
+    {
+        var container = CreateContainer();
+        // RootHoldingSomeConfig.Inner is abstract SomeConfig with [ResolutionKey] string Type.
+        // SomeConfig has concrete subtypes ConfigOne / ConfigTwo (via [ResolutionKeyValue]).
+        // "UnknownVariant" matches neither → ResolveByKey returns null → ArgumentException.
+        var data = new Dictionary<string[], string> { [new[] { "inner", "type" }] = "UnknownVariant" };
+
+        await container.AddConfigurationAsync<RootHoldingSomeConfig>(
+            cfg => cfg.Add(data),
+            TestContext.Current.CancellationToken
+        );
+        var sp = container.BuildServiceProvider();
+
+        Wrap.It(() => sp.Resolve<RootHoldingSomeConfig>()).Throws<ArgumentException>();
+    }
+
+    /// <summary>Wrapper type holding an abstract <see cref="SomeConfig"/> member.</summary>
+    public sealed record RootHoldingSomeConfig
+    {
+        /// <summary>The abstract member; resolved by its [ResolutionKey] Type property.</summary>
+        public SomeConfig Inner { get; set; } = new ConfigOne();
+    }
+
+    /// <summary>
+    /// The sync <c>AddConfiguration&lt;T&gt;(T instance)</c> overload recurses through nested
+    /// property types: a two-level-deep nested record is reachable from the built provider.
+    /// </summary>
+    [Fact]
+    public void AddConfiguration_DeepNestedProperties_AllResolvable()
+    {
+        var container = CreateContainer();
+        var root = new RootCfg { A = new Level1Cfg { B = new Level2Cfg { Value = 42 } } };
+
+        container.AddConfiguration(root);
+
+        var sp = container.BuildServiceProvider();
+        sp.Resolve<RootCfg>().A.B.Value.Is(42);
+        sp.Resolve<Level1Cfg>().B.Value.Is(42);
+        sp.Resolve<Level2Cfg>().Value.Is(42);
+    }
+
+    /// <summary>Two-level config root.</summary>
+    public sealed record RootCfg
+    {
+        /// <summary>Level 1 property.</summary>
+        public Level1Cfg A { get; set; } = new();
+    }
+
+    /// <summary>Two-level config inner.</summary>
+    public sealed record Level1Cfg
+    {
+        /// <summary>Level 2 property.</summary>
+        public Level2Cfg B { get; set; } = new();
+    }
+
+    /// <summary>Two-level config leaf.</summary>
+    public sealed record Level2Cfg
+    {
+        /// <summary>Leaf value.</summary>
+        public int Value { get; set; }
     }
 }

--- a/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ProcessorEdgeCaseTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ProcessorEdgeCaseTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Annium.Configuration.Tests.Lib;
+using Annium.Core.DependencyInjection;
+using Annium.Core.Mapper;
+using Annium.Core.Runtime;
+using Annium.Logging.Shared;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Configuration.Abstractions.Tests;
+
+/// <summary>
+/// Edge-case tests for <c>ConfigurationProcessor</c> and the <c>KeyComparer</c> used by
+/// <c>ConfigurationContainer</c>. These cover defensive throw paths that were previously
+/// unverified by the suite.
+/// </summary>
+public class ProcessorEdgeCaseTests
+{
+    /// <summary>
+    /// Builds a minimal <see cref="ServiceContainer"/> with the registrations
+    /// <c>AddConfigurationAsync</c> needs (runtime types + mapper).
+    /// </summary>
+    private static ServiceContainer CreateContainer()
+    {
+        var container = new ServiceContainer();
+        container.AddRuntime(Assembly.GetExecutingAssembly());
+        container.AddTime().WithRealTime().SetDefault();
+        container.AddLogging();
+        container.AddMapper(autoload: false);
+        return container;
+    }
+
+    /// <summary>
+    /// When configuration data has a non-leaf descendant for a primitive-element list
+    /// (<c>[array, 0, garbage]</c> instead of <c>[array, 0]</c>), the processor reaches
+    /// <c>ProcessValue</c> with a path that has no exact entry and throws
+    /// <see cref="ArgumentException"/>.
+    /// </summary>
+    [Fact]
+    public async Task Process_MissingRequiredLeafKey_ThrowsArgumentException()
+    {
+        var container = CreateContainer();
+        var malformed = new Dictionary<string[], string>
+        {
+            // GetDescendants("array") returns "0"; pushed path becomes ["array", "0"]; processor
+            // calls Process(typeof(int)) → ProcessValue → TryGetValue(["array","0"]) is false
+            // because only the deeper key exists.
+            [new[] { "array", "0", "garbage" }] = "5",
+        };
+
+        await container.AddConfigurationAsync<Config>(cfg => cfg.Add(malformed), TestContext.Current.CancellationToken);
+        var sp = container.BuildServiceProvider();
+
+        // Build<T> runs lazily inside the singleton factory; throw fires on first resolve.
+        Wrap.It(() => sp.Resolve<Config>()).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// When the target abstract type has no property marked with <c>[ResolutionKey]</c>, the
+    /// processor cannot pick a concrete implementation and throws <see cref="ArgumentException"/>.
+    /// </summary>
+    [Fact]
+    public async Task Process_AbstractTypeWithoutResolutionKey_ThrowsArgumentException()
+    {
+        var container = CreateContainer();
+        // No ResolutionKey-marked property on AbstractWithoutResolutionKey → processor cannot
+        // resolve which concrete type to materialize.
+        var data = new Dictionary<string[], string> { [new[] { "leaf", "value" }] = "1" };
+
+        await container.AddConfigurationAsync<RootHoldingAbstract>(
+            cfg => cfg.Add(data),
+            TestContext.Current.CancellationToken
+        );
+        var sp = container.BuildServiceProvider();
+
+        // Build<T> runs lazily inside the singleton factory; throw fires on first resolve.
+        Wrap.It(() => sp.Resolve<RootHoldingAbstract>()).Throws<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Two keys that differ only in case fold to the same bucket — the later <c>Add</c> wins.
+    /// </summary>
+    [Fact]
+    public void Add_KeysDifferingOnlyInCase_LastWins()
+    {
+        var container = ConfigurationFactory.CreateContainer();
+        container.Add(new Dictionary<string[], string> { [new[] { "Plain" }] = "first" });
+        container.Add(new Dictionary<string[], string> { [new[] { "plain" }] = "second" });
+
+        var data = container.Get();
+
+        data.Count.Is(1);
+        data.At(new[] { "Plain" }).Is("second");
+        data.At(new[] { "plain" }).Is("second");
+    }
+
+    /// <summary>
+    /// The internal <c>KeyComparer</c> hashes case variants to the same bucket, which is the
+    /// invariant that makes <see cref="Add_KeysDifferingOnlyInCase_LastWins"/> work. We
+    /// indirectly verify this by exercising the bucket-collision behavior via the public API:
+    /// two adds with different casing produce a single dictionary entry.
+    /// </summary>
+    [Fact]
+    public void KeyComparer_GetHashCode_SameForCaseVariants()
+    {
+        var container = ConfigurationFactory.CreateContainer();
+        container.Add(
+            new Dictionary<string[], string>
+            {
+                [new[] { "section", "Plain" }] = "v1",
+                [new[] { "section", "plain" }] = "v2",
+            }
+        );
+
+        // Both entries fold to the same bucket; only one survives.
+        container.Get().Count.Is(1);
+    }
+
+    /// <summary>
+    /// Wrapper type holding an abstract member whose runtime type cannot be selected because
+    /// <see cref="AbstractWithoutResolutionKey"/> exposes no <c>[ResolutionKey]</c> property.
+    /// </summary>
+    public sealed record RootHoldingAbstract
+    {
+        /// <summary>The abstract leaf the processor will try to resolve.</summary>
+        public AbstractWithoutResolutionKey Leaf { get; set; } = new ConcreteOne();
+    }
+
+    /// <summary>
+    /// Abstract record with no <c>[ResolutionKey]</c>-marked property — the processor will
+    /// throw <see cref="ArgumentException"/> when asked to materialize this.
+    /// </summary>
+    public abstract record AbstractWithoutResolutionKey
+    {
+        /// <summary>A plain string value used by concrete implementations.</summary>
+        public string Value { get; set; } = string.Empty;
+    }
+
+    /// <summary>Concrete subtype of <see cref="AbstractWithoutResolutionKey"/>.</summary>
+    public sealed record ConcreteOne : AbstractWithoutResolutionKey;
+
+    /// <summary>
+    /// Reading an object configuration where a <c>Nullable&lt;T&gt;</c> value-type property carries a
+    /// non-null value exercises the <c>TypeVariant.Nullable</c> unwrap branch in
+    /// <c>ObjectConfigurationProvider</c>. The flattened result must carry the underlying value
+    /// as a string.
+    /// </summary>
+    [Fact]
+    public async Task Read_ObjectWithNonNullNullableField_FlattensProperly()
+    {
+        var container = CreateContainer();
+        var sentinel = new Config { Nullable = 99m };
+
+        await container.AddConfigurationAsync<Config>(cfg => cfg.Add(sentinel), TestContext.Current.CancellationToken);
+
+        var resolved = container.BuildServiceProvider().Resolve<Config>();
+        resolved.Nullable.HasValue.IsTrue();
+        resolved.Nullable!.Value.Is(99m);
+    }
+
+    /// <summary>
+    /// The sync <c>AddConfiguration&lt;T&gt;(T instance)</c> overload registers the configuration
+    /// AND its nested object properties as singletons resolvable from the built provider.
+    /// </summary>
+    [Fact]
+    public void AddConfiguration_SyncOverload_RegistersConfigAndNestedSingleton()
+    {
+        var container = CreateContainer();
+        var cfg = new Config
+        {
+            Plain = 5,
+            Nested = new Val { Plain = 3 },
+        };
+
+        container.AddConfiguration(cfg);
+
+        var sp = container.BuildServiceProvider();
+        sp.Resolve<Config>().Plain.Is(5);
+        sp.Resolve<Val>().Plain.Is(3);
+    }
+}

--- a/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ProcessorEdgeCaseTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ProcessorEdgeCaseTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Annium.Configuration.Tests.Lib;
@@ -234,6 +235,70 @@ public class ProcessorEdgeCaseTests
     {
         /// <summary>Leaf value.</summary>
         public int Value { get; set; }
+    }
+
+    /// <summary>
+    /// When a dictionary property on a config object has an entry whose key is null,
+    /// <c>ObjectConfigurationProvider.ProcessDictionary</c> throws
+    /// <see cref="InvalidOperationException"/> with a message containing "key is null".
+    /// Standard <c>Dictionary&lt;TKey,TValue&gt;</c> forbids null keys, so the test supplies a
+    /// minimal custom <see cref="IReadOnlyDictionary{TKey,TValue}"/> whose enumerator yields
+    /// a <see cref="KeyValuePair{TKey,TValue}"/> with a null Key — the only way to reach the guard.
+    /// </summary>
+    [Fact]
+    public async Task ProcessDictionary_NullKey_ThrowsInvalidOperationException()
+    {
+        var container = ConfigurationFactory.CreateContainer();
+        var instance = new CfgWithNullKeyDict
+        {
+            Data = new NullKeyDictionary<string>("value"),
+        };
+
+        container.Add(instance);
+
+        var ex = await Wrap.It(async () => await container.BuildAsync(TestContext.Current.CancellationToken))
+            .ThrowsAsync<AggregateException>();
+        ex.InnerExceptions.Has(1);
+        var inner = ex.InnerExceptions[0].As<InvalidOperationException>();
+        inner.Message.Contains("key is null").IsTrue($"expected message containing 'key is null'; got: {inner.Message}");
+    }
+
+    /// <summary>Config type whose <see cref="Data"/> property is an <see cref="IReadOnlyDictionary{TKey,TValue}"/>
+    /// — the provider detects it via the interface check and routes to <c>ProcessDictionary</c>.</summary>
+    public sealed class CfgWithNullKeyDict
+    {
+        /// <summary>Dictionary property that will be handed to ProcessDictionary.</summary>
+        public IReadOnlyDictionary<string?, string> Data { get; set; } = new NullKeyDictionary<string>(string.Empty);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IReadOnlyDictionary{TKey,TValue}"/> implementation whose only enumerator
+    /// entry has a null key. Used solely to exercise the null-key guard in
+    /// <c>ObjectConfigurationProvider.ProcessDictionary</c>.
+    /// </summary>
+    private sealed class NullKeyDictionary<TValue> : IReadOnlyDictionary<string?, TValue>
+    {
+        private readonly TValue _value;
+
+        public NullKeyDictionary(TValue value) => _value = value;
+
+        public int Count => 1;
+        public IEnumerable<string?> Keys => new string?[] { null };
+        public IEnumerable<TValue> Values => new[] { _value };
+        public TValue this[string? key] => _value;
+        public bool ContainsKey(string? key) => key is null;
+        public bool TryGetValue(string? key, out TValue value)
+        {
+            value = _value;
+            return key is null;
+        }
+
+        public IEnumerator<KeyValuePair<string?, TValue>> GetEnumerator()
+        {
+            yield return new KeyValuePair<string?, TValue>(null, _value);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     /// <summary>

--- a/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ProcessorEdgeCaseTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ProcessorEdgeCaseTests.cs
@@ -235,4 +235,143 @@ public class ProcessorEdgeCaseTests
         /// <summary>Leaf value.</summary>
         public int Value { get; set; }
     }
+
+    /// <summary>
+    /// Self-referential config type — <c>AddConfiguration</c>'s recursive
+    /// <c>Register</c> must use a visited-set to avoid <see cref="System.StackOverflowException"/>.
+    /// Removing the visited guard at <c>ServiceContainerExtensions.Register</c> would crash here.
+    /// </summary>
+    [Fact]
+    public void AddConfiguration_SelfReferentialType_NoStackOverflow()
+    {
+        var container = CreateContainer();
+        var instance = new SelfRefCfg { Value = 1 };
+
+        container.AddConfiguration(instance);
+
+        var sp = container.BuildServiceProvider();
+        sp.Resolve<SelfRefCfg>().Value.Is(1);
+    }
+
+    /// <summary>
+    /// Config type with a property of its own type — the visited-set guard prevents
+    /// infinite recursion when <c>Register</c> walks nested properties.
+    /// </summary>
+    public sealed class SelfRefCfg
+    {
+        /// <summary>Leaf value.</summary>
+        public int Value { get; set; }
+
+        /// <summary>Self-reference: same type as the enclosing class.</summary>
+        public SelfRefCfg? Self { get; set; }
+    }
+
+    /// <summary>
+    /// Round-trip a list with 12 elements through the object provider + processor pipeline.
+    /// Without the numeric sort fix in <c>ProcessList</c>, index "10" would land before "2"
+    /// (lexicographic) and the reconstructed list would have wrong ordering.
+    /// </summary>
+    [Fact]
+    public async Task Process_ListWith12Elements_OrdersNumerically()
+    {
+        var container = CreateContainer();
+        var expected = new[] { 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210 };
+        var instance = new BigListCfg { Items = [.. expected] };
+
+        await container.AddConfigurationAsync<BigListCfg>(
+            cfg => cfg.Add(instance),
+            TestContext.Current.CancellationToken
+        );
+        var sp = container.BuildServiceProvider();
+
+        var resolved = sp.Resolve<BigListCfg>();
+        resolved.Items.Has(12);
+        for (var i = 0; i < expected.Length; i++)
+            resolved.Items[i].Is(expected[i]);
+    }
+
+    /// <summary>Config holding a 12+-element list of integers for numeric-index ordering verification.</summary>
+    public sealed record BigListCfg
+    {
+        /// <summary>The list under test.</summary>
+        public List<int> Items { get; set; } = new();
+    }
+
+    /// <summary>
+    /// A null entry in an enumerable source value is silently skipped by
+    /// <c>ObjectConfigurationProvider.ProcessEnumerable</c>. Index is only incremented
+    /// for non-null items, so the resulting flat key set compacts nulls out (no gap
+    /// indices in the reconstructed list).
+    /// </summary>
+    [Fact]
+    public async Task Process_ListWithNullEntry_CompactsOutNullEntries()
+    {
+        var container = CreateContainer();
+        var instance = new NullableListCfg { Items = ["a", null, "c"] };
+
+        await container.AddConfigurationAsync<NullableListCfg>(
+            cfg => cfg.Add(instance),
+            TestContext.Current.CancellationToken
+        );
+        var sp = container.BuildServiceProvider();
+
+        var resolved = sp.Resolve<NullableListCfg>();
+        // Null at source-index 1 is skipped before the index counter increments → the
+        // reconstructed list has 2 elements, "a" and "c", with no null in the middle.
+        resolved.Items.Has(2);
+        resolved.Items[0].Is("a");
+        resolved.Items[1].Is("c");
+    }
+
+    /// <summary>Config holding a list with nullable elements for enumerable-null-skip verification.</summary>
+    public sealed record NullableListCfg
+    {
+        /// <summary>The list under test (may include nulls).</summary>
+        public List<string?> Items { get; set; } = new();
+    }
+
+    /// <summary>
+    /// A non-integer key at a list path is malformed source data. <c>ProcessList</c>'s
+    /// <c>int.TryParse</c> guard throws <see cref="InvalidOperationException"/> with the
+    /// offending key and path — not a bare <c>FormatException</c>.
+    /// </summary>
+    [Fact]
+    public async Task Process_ListWithNonIntegerIndex_ThrowsInvalidOperationException()
+    {
+        var container = CreateContainer();
+        // Raw flattened data with a non-integer segment under the "items" list path.
+        var data = new Dictionary<string[], string> { [new[] { "items", "notAnIndex" }] = "5" };
+
+        await container.AddConfigurationAsync<BigListCfg>(
+            cfg => cfg.Add(data),
+            TestContext.Current.CancellationToken
+        );
+        var sp = container.BuildServiceProvider();
+
+        var ex = Wrap.It(() => sp.Resolve<BigListCfg>()).Throws<InvalidOperationException>();
+        ex.Message.Contains("notAnIndex").IsTrue($"expected message naming the bad index; got: {ex.Message}");
+    }
+
+    /// <summary>
+    /// Properties absent from the configuration retain their constructor defaults — the
+    /// <c>if (KeyExists())</c> guard in <c>ProcessObject</c> skips them rather than forcing
+    /// <c>Process</c> (which would throw on the missing leaf). Supplying only <c>Plain</c>
+    /// leaves <c>Nested</c> / <c>List</c> / <c>Array</c> at their defaults.
+    /// </summary>
+    [Fact]
+    public async Task Process_PartialConfig_AbsentPropertiesRetainDefaults()
+    {
+        var container = CreateContainer();
+        var data = new Dictionary<string[], string> { [new[] { "plain" }] = "5" };
+
+        await container.AddConfigurationAsync<Config>(cfg => cfg.Add(data), TestContext.Current.CancellationToken);
+        var sp = container.BuildServiceProvider();
+
+        var resolved = sp.Resolve<Config>();
+        resolved.Plain.Is(5);
+        // Absent keys keep constructor defaults instead of throwing on missing leaves.
+        resolved.Nested.Plain.Is(0);
+        resolved.List.IsEmpty();
+        resolved.Array.IsEmpty();
+    }
 }

--- a/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ProcessorEdgeCaseTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ProcessorEdgeCaseTests.cs
@@ -249,10 +249,7 @@ public class ProcessorEdgeCaseTests
     public async Task ProcessDictionary_NullKey_ThrowsInvalidOperationException()
     {
         var container = ConfigurationFactory.CreateContainer();
-        var instance = new CfgWithNullKeyDict
-        {
-            Data = new NullKeyDictionary<string>("value"),
-        };
+        var instance = new CfgWithNullKeyDict { Data = new NullKeyDictionary<string>("value") };
 
         container.Add(instance);
 
@@ -260,7 +257,9 @@ public class ProcessorEdgeCaseTests
             .ThrowsAsync<AggregateException>();
         ex.InnerExceptions.Has(1);
         var inner = ex.InnerExceptions[0].As<InvalidOperationException>();
-        inner.Message.Contains("key is null").IsTrue($"expected message containing 'key is null'; got: {inner.Message}");
+        inner
+            .Message.Contains("key is null")
+            .IsTrue($"expected message containing 'key is null'; got: {inner.Message}");
     }
 
     /// <summary>Config type whose <see cref="Data"/> property is an <see cref="IReadOnlyDictionary{TKey,TValue}"/>
@@ -286,7 +285,9 @@ public class ProcessorEdgeCaseTests
         public IEnumerable<string?> Keys => new string?[] { null };
         public IEnumerable<TValue> Values => new[] { _value };
         public TValue this[string? key] => _value;
+
         public bool ContainsKey(string? key) => key is null;
+
         public bool TryGetValue(string? key, out TValue value)
         {
             value = _value;
@@ -407,10 +408,7 @@ public class ProcessorEdgeCaseTests
         // Raw flattened data with a non-integer segment under the "items" list path.
         var data = new Dictionary<string[], string> { [new[] { "items", "notAnIndex" }] = "5" };
 
-        await container.AddConfigurationAsync<BigListCfg>(
-            cfg => cfg.Add(data),
-            TestContext.Current.CancellationToken
-        );
+        await container.AddConfigurationAsync<BigListCfg>(cfg => cfg.Add(data), TestContext.Current.CancellationToken);
         var sp = container.BuildServiceProvider();
 
         var ex = Wrap.It(() => sp.Resolve<BigListCfg>()).Throws<InvalidOperationException>();

--- a/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ServiceContainerExtensionsTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Abstractions.Tests/ServiceContainerExtensionsTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using Annium.Configuration.Tests.Lib;
+using Annium.Core.DependencyInjection;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Configuration.Abstractions.Tests;
+
+/// <summary>
+/// Tests for <c>ServiceContainerExtensions.GetRegisteredProperties</c> exclusion predicates.
+/// Verifies that only reference-type non-enum non-primitive non-IEnumerable properties of
+/// a configuration type are registered as singletons in the built service provider.
+/// </summary>
+public class ServiceContainerExtensionsTests
+{
+    private static ServiceContainer CreateContainer() => TestContainerFactory.Create();
+
+    /// <summary>
+    /// After AddConfiguration with a fully populated Config instance, both the root Config and
+    /// the nested Val (Nested property — reference type) are resolvable from the provider.
+    /// This anchors that the registration ran and that non-excluded properties are registered.
+    /// </summary>
+    [Fact]
+    public void AddConfiguration_ReferenceTypeProperties_AreResolvable()
+    {
+        var container = CreateContainer();
+        var cfg = new Config { Nested = new Val { Plain = 3 } };
+
+        container.AddConfiguration(cfg);
+
+        var sp = container.BuildServiceProvider();
+        sp.Resolve<Config>().Nested.Plain.Is(3);
+        sp.Resolve<Val>().Plain.Is(3);
+    }
+
+    /// <summary>
+    /// The SomeConfig abstract reference-type property (Abstract) is also registered,
+    /// proving that abstract reference types are not excluded by the predicate.
+    /// </summary>
+    [Fact]
+    public void AddConfiguration_AbstractReferenceTypeProperty_IsResolvable()
+    {
+        var container = CreateContainer();
+        var cfg = new Config { Abstract = new ConfigOne { Value = 7 } };
+
+        container.AddConfiguration(cfg);
+
+        var sp = container.BuildServiceProvider();
+        sp.Resolve<SomeConfig>().IsNotDefault();
+    }
+
+    /// <summary>
+    /// The Plain int property (value type) is excluded by the IsValueType predicate.
+    /// Resolving int from the provider throws InvalidOperationException because int
+    /// is never registered.
+    /// </summary>
+    [Fact]
+    public void AddConfiguration_ValueTypeProperty_IsNotRegistered()
+    {
+        var container = CreateContainer();
+        container.AddConfiguration(new Config { Plain = 5 });
+
+        var sp = container.BuildServiceProvider();
+
+        Wrap.It(() => sp.Resolve<int>()).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// The Enum SomeEnum property is excluded by the IsEnum predicate.
+    /// Resolving SomeEnum from the provider throws InvalidOperationException because
+    /// enum types are never registered.
+    /// </summary>
+    [Fact]
+    public void AddConfiguration_EnumProperty_IsNotRegistered()
+    {
+        var container = CreateContainer();
+        container.AddConfiguration(new Config());
+
+        var sp = container.BuildServiceProvider();
+
+        Wrap.It(() => sp.Resolve<SomeEnum>()).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// The Array int[] property is excluded by the IEnumerable&lt;&gt; predicate.
+    /// Resolving int[] from the provider throws InvalidOperationException because
+    /// array types implement IEnumerable&lt;T&gt; and are filtered out.
+    /// </summary>
+    [Fact]
+    public void AddConfiguration_ArrayProperty_IsNotRegistered()
+    {
+        var container = CreateContainer();
+        container.AddConfiguration(new Config());
+
+        var sp = container.BuildServiceProvider();
+
+        Wrap.It(() => sp.Resolve<int[]>()).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// The List&lt;Val&gt; property is excluded by the IEnumerable&lt;&gt; predicate.
+    /// Resolving List&lt;Val&gt; from the provider throws InvalidOperationException because
+    /// List&lt;T&gt; implements IEnumerable&lt;T&gt; and is filtered out.
+    /// </summary>
+    [Fact]
+    public void AddConfiguration_ListProperty_IsNotRegistered()
+    {
+        var container = CreateContainer();
+        container.AddConfiguration(new Config());
+
+        var sp = container.BuildServiceProvider();
+
+        Wrap.It(() => sp.Resolve<List<Val>>()).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// The Dictionary&lt;string, Val&gt; property is excluded by the IEnumerable&lt;&gt; predicate
+    /// (Dictionary implements IEnumerable&lt;KeyValuePair&lt;,&gt;&gt;).
+    /// Resolving Dictionary&lt;string, Val&gt; from the provider throws InvalidOperationException.
+    /// </summary>
+    [Fact]
+    public void AddConfiguration_DictionaryProperty_IsNotRegistered()
+    {
+        var container = CreateContainer();
+        container.AddConfiguration(new Config());
+
+        var sp = container.BuildServiceProvider();
+
+        Wrap.It(() => sp.Resolve<Dictionary<string, Val>>()).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// A string property is excluded by the IEnumerable&lt;&gt; predicate (string implements
+    /// IEnumerable&lt;char&gt;), despite being a non-value, non-enum, non-primitive reference type.
+    /// SomeConfig.Type (reached by recursion into the Abstract property) is such a property;
+    /// resolving string from the provider throws because string is never registered.
+    /// </summary>
+    [Fact]
+    public void AddConfiguration_StringProperty_IsNotRegistered()
+    {
+        var container = CreateContainer();
+        container.AddConfiguration(new Config { Abstract = new ConfigOne { Value = 1 } });
+
+        var sp = container.BuildServiceProvider();
+
+        Wrap.It(() => sp.Resolve<string>()).Throws<InvalidOperationException>();
+    }
+}

--- a/base/Configuration/tests/Annium.Configuration.CommandLine.Tests/CommandLineConfigurationProviderTest.cs
+++ b/base/Configuration/tests/Annium.Configuration.CommandLine.Tests/CommandLineConfigurationProviderTest.cs
@@ -40,7 +40,8 @@ public class CommandLineConfigurationProviderTest : TestBase
         result.IsNotDefault();
         result.Flag.IsTrue();
         result.Plain.Is(7);
-        // result.Nullable.Is(3);
+        result.Nullable.IsNotDefault();
+        result.Nullable.Value.Is(3m);
         result.Array.SequenceEqual(new[] { 4, 7 }).IsTrue();
         result.Nested.Plain.IsEqual(4);
         result.Nested.Array.SequenceEqual(new[] { 4m, 13m }).IsTrue();

--- a/base/Configuration/tests/Annium.Configuration.CommandLine.Tests/CommandLineMultiOptionTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.CommandLine.Tests/CommandLineMultiOptionTests.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Annium.Configuration.Abstractions;
+using Annium.Configuration.Tests.Lib;
+using Annium.Core.DependencyInjection;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Configuration.CommandLine.Tests;
+
+/// <summary>
+/// Tests for the third-and-later occurrence path of a repeated command-line option key.
+/// Covers the <c>multiOptions.ContainsKey(name)</c> branch in
+/// <c>CommandLineConfigurationProvider.Read()</c> that is reached only when the same
+/// option appears three or more times.
+/// </summary>
+public class CommandLineMultiOptionTests
+{
+    private static ServiceContainer CreateContainer() => TestContainerFactory.Create();
+
+    /// <summary>
+    /// When the same option key is supplied three times on the command line, all three
+    /// values are collected and the resolved array contains all three entries in order.
+    /// The third occurrence exercises the <c>multiOptions.ContainsKey(name)</c> Add path
+    /// that is not covered when the key appears only twice.
+    /// </summary>
+    [Fact]
+    public async Task AddCommandLineArgs_OptionRepeatedThreeTimes_AllValuesCollected()
+    {
+        var container = CreateContainer();
+        var args = new[] { "-array", "4", "-array", "7", "-array", "10" };
+
+        await container.AddConfigurationAsync<Config>(
+            x => x.AddCommandLineArgs(args),
+            TestContext.Current.CancellationToken
+        );
+
+        var sp = container.BuildServiceProvider();
+        var resolved = sp.Resolve<Config>();
+
+        resolved.Array.SequenceEqual(new[] { 4, 7, 10 }).IsTrue();
+    }
+}

--- a/base/Configuration/tests/Annium.Configuration.CommandLine.Tests/CommandLineSourceTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.CommandLine.Tests/CommandLineSourceTests.cs
@@ -70,4 +70,19 @@ public class CommandLineSourceTests
             $"executable path '{executablePath}' must not appear as a configuration key (Skip(1) on env args)"
         );
     }
+
+    /// <summary>
+    /// Arguments with no leading dash are positional and skipped by <c>IsPosition</c>; an
+    /// all-positional input therefore produces an empty configuration result.
+    /// </summary>
+    [Fact]
+    public async Task Read_PositionalOnlyArgs_ProducesEmptyResult()
+    {
+        var container = ConfigurationFactory.CreateContainer();
+        container.AddCommandLineArgs(new[] { "positional", "another" });
+
+        await container.BuildAsync(TestContext.Current.CancellationToken);
+
+        container.Get().Count.Is(0);
+    }
 }

--- a/base/Configuration/tests/Annium.Configuration.CommandLine.Tests/CommandLineSourceTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.CommandLine.Tests/CommandLineSourceTests.cs
@@ -31,6 +31,22 @@ public class CommandLineSourceTests
     }
 
     /// <summary>
+    /// Double-dash option syntax (<c>--section.key value</c>) is parsed by <c>ParseName</c>:
+    /// leading dashes are stripped via the <c>^-+</c> regex and segments are PascalCased.
+    /// </summary>
+    [Fact]
+    public async Task Read_DoubleDashOption_ParsedCorrectly()
+    {
+        var container = ConfigurationFactory.CreateContainer();
+        container.AddCommandLineArgs(new[] { "--section.key", "value" });
+
+        await container.BuildAsync(TestContext.Current.CancellationToken);
+
+        var data = container.Get();
+        data.At(new[] { "Section", "Key" }).Is("value");
+    }
+
+    /// <summary>
     /// When args is null, the source reads <see cref="Environment.GetCommandLineArgs"/> and
     /// must skip the executable path at index 0. The executable path is a positional argument
     /// (no leading dash) and therefore must never appear as a key in the flattened result.

--- a/base/Configuration/tests/Annium.Configuration.CommandLine.Tests/CommandLineSourceTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.CommandLine.Tests/CommandLineSourceTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Annium.Configuration.Abstractions;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Configuration.CommandLine.Tests;
+
+/// <summary>
+/// Edge-case tests for <c>AddCommandLineArgs</c> covering the duplicate-flag exception path
+/// and the null-args branch that delegates to <see cref="Environment.GetCommandLineArgs"/>.
+/// </summary>
+public class CommandLineSourceTests
+{
+    /// <summary>
+    /// Passing the same flag twice raises an <see cref="Exception"/> wrapped in
+    /// <see cref="AggregateException"/> by <c>BuildAsync</c>.
+    /// </summary>
+    [Fact]
+    public async Task Read_DuplicateFlag_ThrowsException()
+    {
+        var container = ConfigurationFactory.CreateContainer();
+        container.AddCommandLineArgs(new[] { "-flag", "-flag" });
+
+        var ex = await Wrap.It(async () => await container.BuildAsync(TestContext.Current.CancellationToken))
+            .ThrowsAsync<AggregateException>();
+        ex.InnerExceptions.Has(1);
+        var inner = ex.InnerExceptions[0];
+        inner.Message.Contains("flag").IsTrue($"expected message to mention the flag; got: {inner.Message}");
+    }
+
+    /// <summary>
+    /// When args is null, the source reads <see cref="Environment.GetCommandLineArgs"/> and
+    /// must skip the executable path at index 0. The executable path is a positional argument
+    /// (no leading dash) and therefore must never appear as a key in the flattened result.
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_NullArgs_UsesEnvironmentArgsSkippingExecutable()
+    {
+        var container = ConfigurationFactory.CreateContainer();
+        // optional: true keeps this test stable across test-host arg shapes (e.g. a
+        // duplicate flag in the env would otherwise fail BuildAsync).
+        container.AddCommandLineArgs(args: null, optional: true);
+
+        await container.BuildAsync(TestContext.Current.CancellationToken);
+
+        var executablePath = Environment.GetCommandLineArgs()[0];
+        var data = container.Get();
+        var hasExecutableKey = data.Keys.Any(k =>
+            string.Join(".", k).Equals(executablePath, StringComparison.OrdinalIgnoreCase)
+        );
+        hasExecutableKey.IsFalse(
+            $"executable path '{executablePath}' must not appear as a configuration key (Skip(1) on env args)"
+        );
+    }
+}

--- a/base/Configuration/tests/Annium.Configuration.Json.Tests/BuildAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Json.Tests/BuildAsyncTests.cs
@@ -168,8 +168,7 @@ public class BuildAsyncTests
         var container = ConfigurationFactory.CreateContainer();
         container.AddRemoteJson(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(30));
 
-        var ex = await Wrap.It(async () => await container.BuildAsync(cts.Token))
-            .ThrowsAsync<AggregateException>();
+        var ex = await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<AggregateException>();
         ex.InnerExceptions.Has(1);
         var inner = ex.InnerExceptions[0];
         var isCancel = inner is OperationCanceledException;

--- a/base/Configuration/tests/Annium.Configuration.Json.Tests/BuildAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Json.Tests/BuildAsyncTests.cs
@@ -176,6 +176,31 @@ public class BuildAsyncTests
     }
 
     /// <summary>
+    /// A token cancelled WHILE the request is in-flight (not pre-cancelled) surfaces
+    /// <see cref="OperationCanceledException"/>, not <see cref="TimeoutException"/> — the per-source
+    /// timeout is long enough that only the caller's cancellation can fire. Exercises the
+    /// <c>!ct.IsCancellationRequested</c> catch filter at the async suspension point.
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_CtCancelledMidFlight_ThrowsOperationCanceledException()
+    {
+        await using var stub = new HangingTcpListener("config.json");
+        await stub.StartAsync(TestContext.Current.CancellationToken);
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(500));
+
+        var container = ConfigurationFactory.CreateContainer();
+        container.AddRemoteJson(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(30));
+
+        var ex = await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<AggregateException>();
+        ex.InnerExceptions.Has(1);
+        var inner = ex.InnerExceptions[0];
+        var isCancel = inner is OperationCanceledException;
+        isCancel.IsTrue($"expected OperationCanceledException; got {inner.GetType().FullName}: {inner.Message}");
+    }
+
+    /// <summary>
     /// A remote source returning 200 OK with a valid JSON body parses and flattens the
     /// payload into the container — the success branch of <c>RemoteConfigurationSourceBase.LoadAsync</c>.
     /// </summary>

--- a/base/Configuration/tests/Annium.Configuration.Json.Tests/BuildAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Json.Tests/BuildAsyncTests.cs
@@ -168,11 +168,7 @@ public class BuildAsyncTests
         var container = ConfigurationFactory.CreateContainer();
         container.AddRemoteJson(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(30));
 
-        var ex = await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<AggregateException>();
-        ex.InnerExceptions.Has(1);
-        var inner = ex.InnerExceptions[0];
-        var isCancel = inner is OperationCanceledException;
-        isCancel.IsTrue($"expected OperationCanceledException; got {inner.GetType().FullName}: {inner.Message}");
+        await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<OperationCanceledException>();
     }
 
     /// <summary>
@@ -193,11 +189,7 @@ public class BuildAsyncTests
         var container = ConfigurationFactory.CreateContainer();
         container.AddRemoteJson(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(30));
 
-        var ex = await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<AggregateException>();
-        ex.InnerExceptions.Has(1);
-        var inner = ex.InnerExceptions[0];
-        var isCancel = inner is OperationCanceledException;
-        isCancel.IsTrue($"expected OperationCanceledException; got {inner.GetType().FullName}: {inner.Message}");
+        await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<OperationCanceledException>();
     }
 
     /// <summary>

--- a/base/Configuration/tests/Annium.Configuration.Json.Tests/BuildAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Json.Tests/BuildAsyncTests.cs
@@ -100,7 +100,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task BuildAsync_AddRemoteJson_TimeoutNotOptional_Throws()
     {
-        using var stub = new HangingTcpListener("config.json");
+        await using var stub = new HangingTcpListener("config.json");
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();
@@ -121,7 +121,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task BuildAsync_AddRemoteJson_TimeoutOptional_Succeeds()
     {
-        using var stub = new HangingTcpListener("config.json");
+        await using var stub = new HangingTcpListener("config.json");
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();
@@ -139,7 +139,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task LoadAsync_Non2xxResponse_ThrowsHttpRequestException()
     {
-        using var stub = new StaticResponseTcpListener(HttpStatusCode.InternalServerError, "{}", "config.json");
+        await using var stub = new StaticResponseTcpListener(HttpStatusCode.InternalServerError, "{}", "config.json");
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();
@@ -159,7 +159,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task LoadAsync_CtCancelled_ThrowsOperationCanceledException()
     {
-        using var stub = new HangingTcpListener("config.json");
+        await using var stub = new HangingTcpListener("config.json");
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         using var cts = new CancellationTokenSource();
@@ -173,5 +173,29 @@ public class BuildAsyncTests
         var inner = ex.InnerExceptions[0];
         var isCancel = inner is OperationCanceledException;
         isCancel.IsTrue($"expected OperationCanceledException; got {inner.GetType().FullName}: {inner.Message}");
+    }
+
+    /// <summary>
+    /// A remote source returning 200 OK with a valid JSON body parses and flattens the
+    /// payload into the container — the success branch of <c>RemoteConfigurationSourceBase.LoadAsync</c>.
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_SuccessResponse_LoadsRemoteData()
+    {
+        await using var stub = new StaticResponseTcpListener(
+            HttpStatusCode.OK,
+            "{\"plain\":42,\"section\":{\"value\":\"ok\"}}",
+            "config.json"
+        );
+        await stub.StartAsync(TestContext.Current.CancellationToken);
+
+        var container = ConfigurationFactory.CreateContainer();
+        container.AddRemoteJson(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(5));
+
+        await container.BuildAsync(TestContext.Current.CancellationToken);
+
+        var data = container.Get();
+        data.At(new[] { "plain" }).Is("42");
+        data.At(new[] { "section", "value" }).Is("ok");
     }
 }

--- a/base/Configuration/tests/Annium.Configuration.Json.Tests/BuildAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Json.Tests/BuildAsyncTests.cs
@@ -18,6 +18,11 @@ namespace Annium.Configuration.Json.Tests;
 public class BuildAsyncTests
 {
     /// <summary>
+    /// Resource name served by the stub TCP listeners in these tests.
+    /// </summary>
+    private const string ResourcePath = "config.json";
+
+    /// <summary>
     /// An empty container (no sources registered) is a no-op for <c>BuildAsync</c>.
     /// </summary>
     [Fact]
@@ -100,7 +105,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task BuildAsync_AddRemoteJson_TimeoutNotOptional_Throws()
     {
-        await using var stub = new HangingTcpListener("config.json");
+        await using var stub = new HangingTcpListener(ResourcePath);
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();
@@ -121,7 +126,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task BuildAsync_AddRemoteJson_TimeoutOptional_Succeeds()
     {
-        await using var stub = new HangingTcpListener("config.json");
+        await using var stub = new HangingTcpListener(ResourcePath);
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();
@@ -139,7 +144,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task LoadAsync_Non2xxResponse_ThrowsHttpRequestException()
     {
-        await using var stub = new StaticResponseTcpListener(HttpStatusCode.InternalServerError, "{}", "config.json");
+        await using var stub = new StaticResponseTcpListener(HttpStatusCode.InternalServerError, "{}", ResourcePath);
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();
@@ -159,7 +164,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task LoadAsync_CtCancelled_ThrowsOperationCanceledException()
     {
-        await using var stub = new HangingTcpListener("config.json");
+        await using var stub = new HangingTcpListener(ResourcePath);
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         using var cts = new CancellationTokenSource();
@@ -180,7 +185,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task LoadAsync_CtCancelledMidFlight_ThrowsOperationCanceledException()
     {
-        await using var stub = new HangingTcpListener("config.json");
+        await using var stub = new HangingTcpListener(ResourcePath);
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         using var cts = new CancellationTokenSource();
@@ -188,6 +193,27 @@ public class BuildAsyncTests
 
         var container = ConfigurationFactory.CreateContainer();
         container.AddRemoteJson(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(30));
+
+        await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<OperationCanceledException>();
+    }
+
+    /// <summary>
+    /// An OPTIONAL remote source whose token is cancelled mid-flight must still surface
+    /// <see cref="OperationCanceledException"/> — caller cancellation is never silenced by the
+    /// <c>Optional</c> flag (only load failures like timeout are). Covers the optional × mid-flight
+    /// quadrant of the cancellation matrix.
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_OptionalCtCancelledMidFlight_ThrowsOperationCanceledException()
+    {
+        await using var stub = new HangingTcpListener(ResourcePath);
+        await stub.StartAsync(TestContext.Current.CancellationToken);
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(500));
+
+        var container = ConfigurationFactory.CreateContainer();
+        container.AddRemoteJson(stub.Uri, optional: true, timeout: TimeSpan.FromSeconds(30));
 
         await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<OperationCanceledException>();
     }
@@ -202,7 +228,7 @@ public class BuildAsyncTests
         await using var stub = new StaticResponseTcpListener(
             HttpStatusCode.OK,
             "{\"plain\":42,\"section\":{\"value\":\"ok\"}}",
-            "config.json"
+            ResourcePath
         );
         await stub.StartAsync(TestContext.Current.CancellationToken);
 

--- a/base/Configuration/tests/Annium.Configuration.Json.Tests/BuildAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Json.Tests/BuildAsyncTests.cs
@@ -1,13 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Net.Sockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Annium.Configuration.Abstractions;
+using Annium.Configuration.Tests.Lib;
 using Annium.Testing;
 using Xunit;
 
@@ -102,7 +100,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task BuildAsync_AddRemoteJson_TimeoutNotOptional_Throws()
     {
-        using var stub = new HangingTcpListener();
+        using var stub = new HangingTcpListener("config.json");
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();
@@ -123,7 +121,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task BuildAsync_AddRemoteJson_TimeoutOptional_Succeeds()
     {
-        using var stub = new HangingTcpListener();
+        using var stub = new HangingTcpListener("config.json");
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();
@@ -141,7 +139,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task LoadAsync_Non2xxResponse_ThrowsHttpRequestException()
     {
-        using var stub = new StaticResponseTcpListener(HttpStatusCode.InternalServerError, "{}");
+        using var stub = new StaticResponseTcpListener(HttpStatusCode.InternalServerError, "{}", "config.json");
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();
@@ -161,7 +159,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task LoadAsync_CtCancelled_ThrowsOperationCanceledException()
     {
-        using var stub = new HangingTcpListener();
+        using var stub = new HangingTcpListener("config.json");
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         using var cts = new CancellationTokenSource();
@@ -176,142 +174,5 @@ public class BuildAsyncTests
         var inner = ex.InnerExceptions[0];
         var isCancel = inner is OperationCanceledException;
         isCancel.IsTrue($"expected OperationCanceledException; got {inner.GetType().FullName}: {inner.Message}");
-    }
-
-    /// <summary>
-    /// Local TCP listener that accepts connections but never sends a response — used to force
-    /// a deterministic <c>HttpClient</c> timeout trigger regardless of the test host's network
-    /// configuration. Holds strong references to accepted clients so GC can't reap them
-    /// mid-test (which would otherwise close the socket and translate timeout into IO error).
-    /// </summary>
-    private sealed class HangingTcpListener : IDisposable
-    {
-        private readonly TcpListener _listener;
-        private readonly CancellationTokenSource _cts = new();
-        private readonly List<TcpClient> _accepted = new();
-        private readonly TaskCompletionSource _listening = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        public HangingTcpListener()
-        {
-            _listener = new TcpListener(IPAddress.Loopback, 0);
-        }
-
-        public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/config.json");
-
-        public async Task StartAsync(CancellationToken ct)
-        {
-            _listener.Start();
-            _ = Task.Run(async () =>
-            {
-                _listening.TrySetResult();
-                try
-                {
-                    while (!_cts.IsCancellationRequested)
-                    {
-                        var client = await _listener.AcceptTcpClientAsync(_cts.Token);
-                        // Hold a strong reference so GC doesn't reap the socket while the test
-                        // is mid-request — otherwise HttpClient sees an IO error, not a timeout.
-                        lock (_accepted)
-                            _accepted.Add(client);
-                    }
-                }
-                catch (OperationCanceledException) { /* expected on dispose */
-                }
-                catch (ObjectDisposedException) { /* expected on dispose */
-                }
-            });
-
-            await _listening.Task.WaitAsync(ct);
-        }
-
-        public void Dispose()
-        {
-            _cts.Cancel();
-            _listener.Stop();
-            lock (_accepted)
-            {
-                foreach (var c in _accepted)
-                    c.Dispose();
-                _accepted.Clear();
-            }
-            _cts.Dispose();
-        }
-    }
-
-    /// <summary>
-    /// Local TCP listener that returns a fixed HTTP status code + body for any incoming request.
-    /// Used to drive non-2xx response paths without bringing up a full HTTP server.
-    /// </summary>
-    private sealed class StaticResponseTcpListener : IDisposable
-    {
-        private readonly TcpListener _listener;
-        private readonly CancellationTokenSource _cts = new();
-        private readonly HttpStatusCode _status;
-        private readonly string _body;
-        private readonly TaskCompletionSource _listening = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        public StaticResponseTcpListener(HttpStatusCode status, string body)
-        {
-            _status = status;
-            _body = body;
-            _listener = new TcpListener(IPAddress.Loopback, 0);
-        }
-
-        public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/config.json");
-
-        public async Task StartAsync(CancellationToken ct)
-        {
-            _listener.Start();
-            _ = Task.Run(async () =>
-            {
-                _listening.TrySetResult();
-                try
-                {
-                    while (!_cts.IsCancellationRequested)
-                    {
-                        using var client = await _listener.AcceptTcpClientAsync(_cts.Token);
-                        await using var stream = client.GetStream();
-
-                        // Drain the request headers (best-effort) before replying.
-                        var buffer = new byte[4096];
-                        try
-                        {
-                            using var readCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
-                            _ = await stream.ReadAsync(buffer, readCts.Token);
-                        }
-                        catch (OperationCanceledException) { }
-
-                        var bodyBytes = Encoding.UTF8.GetBytes(_body);
-                        var reasonPhrase = _status.ToString();
-                        var header = Encoding.ASCII.GetBytes(
-                            $"HTTP/1.1 {(int)_status} {reasonPhrase}\r\n"
-                                + $"Content-Length: {bodyBytes.Length}\r\n"
-                                + "Content-Type: application/json\r\n"
-                                + "Connection: close\r\n"
-                                + "\r\n"
-                        );
-                        await stream.WriteAsync(header, _cts.Token);
-                        if (bodyBytes.Length > 0)
-                            await stream.WriteAsync(bodyBytes, _cts.Token);
-                        await stream.FlushAsync(_cts.Token);
-                    }
-                }
-                catch (OperationCanceledException) { /* expected on dispose */
-                }
-                catch (ObjectDisposedException) { /* expected on dispose */
-                }
-                catch (IOException) { /* client disconnected */
-                }
-            });
-
-            await _listening.Task.WaitAsync(ct);
-        }
-
-        public void Dispose()
-        {
-            _cts.Cancel();
-            _listener.Stop();
-            _cts.Dispose();
-        }
     }
 }

--- a/base/Configuration/tests/Annium.Configuration.Json.Tests/JsonConfigurationProviderTest.cs
+++ b/base/Configuration/tests/Annium.Configuration.Json.Tests/JsonConfigurationProviderTest.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Annium.Configuration.Abstractions;
 using Annium.Configuration.Tests.Lib;
@@ -85,23 +87,48 @@ public class JsonConfigurationProviderTest : TestBase
         result.Flag.IsTrue();
         result.Plain.Is(7);
         // result.Nullable.Is(3);
-        result.Array.SequenceEqual(new[] { 4, 7 }).IsTrue();
+        Enumerable.SequenceEqual(result.Array, new[] { 4, 7 }).IsTrue();
         result.Matrix.Has(2);
-        result.Matrix.At(0).SequenceEqual(new[] { 3, 2 }).IsTrue();
-        result.Matrix.At(1).SequenceEqual(new[] { 5, 4 }).IsTrue();
+        Enumerable.SequenceEqual(result.Matrix.At(0), new[] { 3, 2 }).IsTrue();
+        Enumerable.SequenceEqual(result.Matrix.At(1), new[] { 5, 4 }).IsTrue();
         result.List.Has(2);
         result.List[0].Plain.Is(8);
         result.List[0].Array.IsEmpty();
         result.List[1].Plain.Is(0);
-        result.List[1].Array.SequenceEqual(new[] { 2m, 6m }).IsTrue();
+        Enumerable.SequenceEqual(result.List[1].Array, new[] { 2m, 6m }).IsTrue();
         IDictionary<string, Val> dict = result.Dictionary;
         dict.Has(1);
         dict.At("demo").Plain.Is(14);
-        dict.At("demo").Array.SequenceEqual(new[] { 3m, 15m }).IsTrue();
+        Enumerable.SequenceEqual(dict.At("demo").Array, new[] { 3m, 15m }).IsTrue();
         result.Nested.Plain.Is(4);
-        result.Nested.Array.SequenceEqual(new[] { 4m, 13m }).IsTrue();
+        Enumerable.SequenceEqual(result.Nested.Array, new[] { 4m, 13m }).IsTrue();
         result.Abstract.As<ConfigTwo>().Value.Is(10);
         result.Abstract.IsEqual(nested);
         nested.Is(new ConfigTwo { Value = 10 });
+    }
+
+    /// <summary>
+    /// Malformed JSON content surfaces as a <see cref="System.Text.Json.JsonException"/> from
+    /// the provider; via the build pipeline it lands wrapped in <see cref="System.AggregateException"/>.
+    /// </summary>
+    [Fact]
+    public async Task Read_MalformedJson_ThrowsJsonException()
+    {
+        var bad = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(bad, "{bad json");
+            var container = ConfigurationFactory.CreateContainer();
+            container.AddJsonFile(bad, optional: false);
+
+            var ex = await Wrap.It(async () => await container.BuildAsync(TestContext.Current.CancellationToken))
+                .ThrowsAsync<AggregateException>();
+            ex.InnerExceptions.Has(1);
+            ex.InnerExceptions[0].As<JsonException>();
+        }
+        finally
+        {
+            File.Delete(bad);
+        }
     }
 }

--- a/base/Configuration/tests/Annium.Configuration.Json.Tests/JsonConfigurationProviderTest.cs
+++ b/base/Configuration/tests/Annium.Configuration.Json.Tests/JsonConfigurationProviderTest.cs
@@ -86,7 +86,8 @@ public class JsonConfigurationProviderTest : TestBase
         result.IsNotDefault();
         result.Flag.IsTrue();
         result.Plain.Is(7);
-        // result.Nullable.Is(3);
+        result.Nullable.IsNotDefault();
+        result.Nullable.Value.Is(3m);
         Enumerable.SequenceEqual(result.Array, new[] { 4, 7 }).IsTrue();
         result.Matrix.Has(2);
         Enumerable.SequenceEqual(result.Matrix.At(0), new[] { 3, 2 }).IsTrue();
@@ -129,6 +130,59 @@ public class JsonConfigurationProviderTest : TestBase
         finally
         {
             File.Delete(bad);
+        }
+    }
+
+    /// <summary>
+    /// JSON null literals (<c>"key": null</c>) reach the default branch of
+    /// <c>JsonConfigurationProvider.Process</c> and produce a string key via
+    /// <c>ProcessLeaf</c>. The flattened result must contain the key.
+    /// </summary>
+    [Fact]
+    public async Task Read_JsonWithNullLeaf_ProducesStringKey()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "{\"key\": null}");
+            var container = ConfigurationFactory.CreateContainer();
+            container.AddJsonFile(path, optional: false);
+
+            await container.BuildAsync(TestContext.Current.CancellationToken);
+
+            var data = container.Get();
+            data.Keys.Any(k => k.Length == 1 && k[0].Equals("key", StringComparison.OrdinalIgnoreCase)).IsTrue();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// JSON boolean literals reach the default branch of <c>JsonConfigurationProvider.Process</c>
+    /// and produce a string key via <c>ProcessLeaf</c>. Both <c>true</c> and <c>false</c> values
+    /// flatten with their token string representation.
+    /// </summary>
+    [Fact]
+    public async Task Read_JsonWithBooleanLeaf_ProducesStringKey()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "{\"flag\": true, \"off\": false}");
+            var container = ConfigurationFactory.CreateContainer();
+            container.AddJsonFile(path, optional: false);
+
+            await container.BuildAsync(TestContext.Current.CancellationToken);
+
+            var data = container.Get();
+            data.Keys.Any(k => k.Length == 1 && k[0].Equals("flag", StringComparison.OrdinalIgnoreCase)).IsTrue();
+            data.Keys.Any(k => k.Length == 1 && k[0].Equals("off", StringComparison.OrdinalIgnoreCase)).IsTrue();
+        }
+        finally
+        {
+            File.Delete(path);
         }
     }
 }

--- a/base/Configuration/tests/Annium.Configuration.Tests.Lib/Annium.Configuration.Tests.Lib.csproj
+++ b/base/Configuration/tests/Annium.Configuration.Tests.Lib/Annium.Configuration.Tests.Lib.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Solutions>Annium.Base</Solutions>
     <OutputType>Library</OutputType>
@@ -6,10 +6,10 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="../../src/Annium.Configuration.Abstractions/Annium.Configuration.Abstractions.csproj" />
     <ProjectReference Include="../../../Core/src/Annium.Core.DependencyInjection/Annium.Core.DependencyInjection.csproj" />
     <ProjectReference Include="../../../Core/src/Annium.Core.Mapper/Annium.Core.Mapper.csproj" />
     <ProjectReference Include="../../../Core/src/Annium.Core.Runtime/Annium.Core.Runtime.csproj" />
     <ProjectReference Include="../../../Logging/src/Annium.Logging.Shared/Annium.Logging.Shared.csproj" />
+    <ProjectReference Include="../../src/Annium.Configuration.Abstractions/Annium.Configuration.Abstractions.csproj" />
   </ItemGroup>
 </Project>

--- a/base/Configuration/tests/Annium.Configuration.Tests.Lib/Annium.Configuration.Tests.Lib.csproj
+++ b/base/Configuration/tests/Annium.Configuration.Tests.Lib/Annium.Configuration.Tests.Lib.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Solutions>Annium.Base</Solutions>
     <OutputType>Library</OutputType>
@@ -7,5 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/Annium.Configuration.Abstractions/Annium.Configuration.Abstractions.csproj" />
+    <ProjectReference Include="../../../Core/src/Annium.Core.DependencyInjection/Annium.Core.DependencyInjection.csproj" />
+    <ProjectReference Include="../../../Core/src/Annium.Core.Mapper/Annium.Core.Mapper.csproj" />
+    <ProjectReference Include="../../../Core/src/Annium.Core.Runtime/Annium.Core.Runtime.csproj" />
+    <ProjectReference Include="../../../Logging/src/Annium.Logging.Shared/Annium.Logging.Shared.csproj" />
   </ItemGroup>
 </Project>

--- a/base/Configuration/tests/Annium.Configuration.Tests.Lib/Config.cs
+++ b/base/Configuration/tests/Annium.Configuration.Tests.Lib/Config.cs
@@ -105,6 +105,9 @@ public sealed record ConfigOne : SomeConfig
     /// </summary>
     public uint Value { get; set; }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="ConfigOne"/>.
+    /// </summary>
     public ConfigOne()
     {
         Type = nameof(ConfigOne);
@@ -122,6 +125,9 @@ public sealed record ConfigTwo : SomeConfig
     /// </summary>
     public long Value { get; set; }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="ConfigTwo"/>.
+    /// </summary>
     public ConfigTwo()
     {
         Type = nameof(ConfigTwo);

--- a/base/Configuration/tests/Annium.Configuration.Tests.Lib/HangingTcpListener.cs
+++ b/base/Configuration/tests/Annium.Configuration.Tests.Lib/HangingTcpListener.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,91 +11,40 @@ namespace Annium.Configuration.Tests.Lib;
 /// configuration. Holds strong references to accepted clients so GC can't reap them
 /// mid-test (which would otherwise close the socket and translate timeout into IO error).
 /// </summary>
-public sealed class HangingTcpListener : IAsyncDisposable
+public sealed class HangingTcpListener : TcpListenerBase
 {
-    private readonly TcpListener _listener;
-    private readonly CancellationTokenSource _cts = new();
     private readonly List<TcpClient> _accepted = new();
-    private readonly TaskCompletionSource _listening = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private readonly string _resourcePath;
-    private Task? _acceptLoop;
 
     /// <summary>
     /// Initializes a new instance.
     /// </summary>
     /// <param name="resourcePath">The resource path appended to the listener's URI (e.g. "config.json").</param>
     public HangingTcpListener(string resourcePath)
+        : base(resourcePath) { }
+
+    /// <inheritdoc />
+    protected override ValueTask HandleClientAsync(TcpClient client, CancellationToken ct)
     {
-        _resourcePath = resourcePath;
-        _listener = new TcpListener(IPAddress.Loopback, 0);
-    }
-
-    /// <summary>
-    /// The loopback URI exposed by this listener.
-    /// </summary>
-    public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/{_resourcePath}");
-
-    /// <summary>
-    /// Starts the listener and awaits the ready signal. The accept loop runs as a
-    /// tracked <see cref="Task"/> stored in a private field so <see cref="DisposeAsync"/>
-    /// can await its completion — propagating any unexpected exception instead of swallowing it.
-    /// </summary>
-    public async Task StartAsync(CancellationToken ct)
-    {
-        _listener.Start();
-        _acceptLoop = Task.Run(async () =>
-        {
-            _listening.TrySetResult();
-            try
-            {
-                while (!_cts.IsCancellationRequested)
-                {
-                    var client = await _listener.AcceptTcpClientAsync(_cts.Token);
-                    // Hold a strong reference so GC doesn't reap the socket while the test
-                    // is mid-request — otherwise HttpClient sees an IO error, not a timeout.
-                    lock (_accepted)
-                        _accepted.Add(client);
-                }
-            }
-            catch (OperationCanceledException)
-            { /* expected on dispose */
-            }
-            catch (ObjectDisposedException)
-            { /* expected on dispose */
-            }
-        });
-
-        await _listening.Task.WaitAsync(ct);
+        // Hold a strong reference so GC doesn't reap the socket while the test
+        // is mid-request — otherwise HttpClient sees an IO error, not a timeout.
+        lock (_accepted)
+            _accepted.Add(client);
+        return ValueTask.CompletedTask;
     }
 
     /// <inheritdoc />
-    public async ValueTask DisposeAsync()
+    protected override async ValueTask CleanupAsync()
     {
-        await _cts.CancelAsync();
-        _listener.Stop();
-        if (_acceptLoop is not null)
-        {
-            try
-            {
-                // VSTHRD003: the accept-loop Task is started in StartAsync above (same instance, same context)
-                // and Cancel + Stop guarantee its termination before this await — safe to await directly.
-#pragma warning disable VSTHRD003
-                await _acceptLoop;
-#pragma warning restore VSTHRD003
-            }
-            catch (OperationCanceledException)
-            { /* expected on cancel */
-            }
-            catch (ObjectDisposedException)
-            { /* expected on listener.Stop */
-            }
-        }
+        // Snapshot under the lock, then dispose outside it — DisposeAsync cannot be awaited
+        // while holding the lock. The accept loop has already terminated by the time Cleanup
+        // runs, so no concurrent Add can race the snapshot.
+        TcpClient[] clients;
         lock (_accepted)
         {
-            foreach (var c in _accepted)
-                c.Dispose();
+            clients = _accepted.ToArray();
             _accepted.Clear();
         }
-        _cts.Dispose();
+        foreach (var c in clients)
+            await c.DisposeAsync();
     }
 }

--- a/base/Configuration/tests/Annium.Configuration.Tests.Lib/HangingTcpListener.cs
+++ b/base/Configuration/tests/Annium.Configuration.Tests.Lib/HangingTcpListener.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Annium.Configuration.Tests.Lib;
+
+/// <summary>
+/// Local TCP listener that accepts connections but never sends a response — used to force
+/// a deterministic <c>HttpClient</c> timeout trigger regardless of the test host's network
+/// configuration. Holds strong references to accepted clients so GC can't reap them
+/// mid-test (which would otherwise close the socket and translate timeout into IO error).
+/// </summary>
+public sealed class HangingTcpListener : IDisposable
+{
+    private readonly TcpListener _listener;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly List<TcpClient> _accepted = new();
+    private readonly TaskCompletionSource _listening = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly string _resourcePath;
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    /// <param name="resourcePath">The resource path appended to the listener's URI (e.g. "config.json").</param>
+    public HangingTcpListener(string resourcePath)
+    {
+        _resourcePath = resourcePath;
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+    }
+
+    /// <summary>
+    /// The loopback URI exposed by this listener.
+    /// </summary>
+    public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/{_resourcePath}");
+
+    /// <summary>
+    /// Starts the listener and awaits the ready signal.
+    /// </summary>
+    public async Task StartAsync(CancellationToken ct)
+    {
+        _listener.Start();
+        _ = Task.Run(async () =>
+        {
+            _listening.TrySetResult();
+            try
+            {
+                while (!_cts.IsCancellationRequested)
+                {
+                    var client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                    // Hold a strong reference so GC doesn't reap the socket while the test
+                    // is mid-request — otherwise HttpClient sees an IO error, not a timeout.
+                    lock (_accepted)
+                        _accepted.Add(client);
+                }
+            }
+            catch (OperationCanceledException) { /* expected on dispose */
+            }
+            catch (ObjectDisposedException) { /* expected on dispose */
+            }
+        });
+
+        await _listening.Task.WaitAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _listener.Stop();
+        lock (_accepted)
+        {
+            foreach (var c in _accepted)
+                c.Dispose();
+            _accepted.Clear();
+        }
+        _cts.Dispose();
+    }
+}

--- a/base/Configuration/tests/Annium.Configuration.Tests.Lib/HangingTcpListener.cs
+++ b/base/Configuration/tests/Annium.Configuration.Tests.Lib/HangingTcpListener.cs
@@ -13,13 +13,14 @@ namespace Annium.Configuration.Tests.Lib;
 /// configuration. Holds strong references to accepted clients so GC can't reap them
 /// mid-test (which would otherwise close the socket and translate timeout into IO error).
 /// </summary>
-public sealed class HangingTcpListener : IDisposable
+public sealed class HangingTcpListener : IAsyncDisposable
 {
     private readonly TcpListener _listener;
     private readonly CancellationTokenSource _cts = new();
     private readonly List<TcpClient> _accepted = new();
     private readonly TaskCompletionSource _listening = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly string _resourcePath;
+    private Task? _acceptLoop;
 
     /// <summary>
     /// Initializes a new instance.
@@ -37,12 +38,14 @@ public sealed class HangingTcpListener : IDisposable
     public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/{_resourcePath}");
 
     /// <summary>
-    /// Starts the listener and awaits the ready signal.
+    /// Starts the listener and awaits the ready signal. The accept loop runs as a
+    /// tracked <see cref="Task"/> stored in a private field so <see cref="DisposeAsync"/>
+    /// can await its completion — propagating any unexpected exception instead of swallowing it.
     /// </summary>
     public async Task StartAsync(CancellationToken ct)
     {
         _listener.Start();
-        _ = Task.Run(async () =>
+        _acceptLoop = Task.Run(async () =>
         {
             _listening.TrySetResult();
             try
@@ -68,10 +71,27 @@ public sealed class HangingTcpListener : IDisposable
     }
 
     /// <inheritdoc />
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
-        _cts.Cancel();
+        await _cts.CancelAsync();
         _listener.Stop();
+        if (_acceptLoop is not null)
+        {
+            try
+            {
+                // VSTHRD003: the accept-loop Task is started in StartAsync above (same instance, same context)
+                // and Cancel + Stop guarantee its termination before this await — safe to await directly.
+#pragma warning disable VSTHRD003
+                await _acceptLoop;
+#pragma warning restore VSTHRD003
+            }
+            catch (OperationCanceledException)
+            { /* expected on cancel */
+            }
+            catch (ObjectDisposedException)
+            { /* expected on listener.Stop */
+            }
+        }
         lock (_accepted)
         {
             foreach (var c in _accepted)

--- a/base/Configuration/tests/Annium.Configuration.Tests.Lib/HangingTcpListener.cs
+++ b/base/Configuration/tests/Annium.Configuration.Tests.Lib/HangingTcpListener.cs
@@ -56,9 +56,11 @@ public sealed class HangingTcpListener : IDisposable
                         _accepted.Add(client);
                 }
             }
-            catch (OperationCanceledException) { /* expected on dispose */
+            catch (OperationCanceledException)
+            { /* expected on dispose */
             }
-            catch (ObjectDisposedException) { /* expected on dispose */
+            catch (ObjectDisposedException)
+            { /* expected on dispose */
             }
         });
 

--- a/base/Configuration/tests/Annium.Configuration.Tests.Lib/StaticResponseTcpListener.cs
+++ b/base/Configuration/tests/Annium.Configuration.Tests.Lib/StaticResponseTcpListener.cs
@@ -1,0 +1,109 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Annium.Configuration.Tests.Lib;
+
+/// <summary>
+/// Local TCP listener that returns a fixed HTTP status code + body for any incoming request.
+/// Used to drive non-2xx response paths without bringing up a full HTTP server.
+/// </summary>
+public sealed class StaticResponseTcpListener : IDisposable
+{
+    private readonly TcpListener _listener;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly HttpStatusCode _status;
+    private readonly string _body;
+    private readonly string _resourcePath;
+    private readonly string _contentType;
+    private readonly TaskCompletionSource _listening = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    /// <param name="status">HTTP status code to return.</param>
+    /// <param name="body">Response body.</param>
+    /// <param name="resourcePath">The resource path appended to the listener's URI (e.g. "config.json").</param>
+    /// <param name="contentType">Response Content-Type header value.</param>
+    public StaticResponseTcpListener(
+        HttpStatusCode status,
+        string body,
+        string resourcePath,
+        string contentType = "application/json"
+    )
+    {
+        _status = status;
+        _body = body;
+        _resourcePath = resourcePath;
+        _contentType = contentType;
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+    }
+
+    /// <summary>
+    /// The loopback URI exposed by this listener.
+    /// </summary>
+    public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/{_resourcePath}");
+
+    /// <summary>
+    /// Starts the listener and awaits the ready signal.
+    /// </summary>
+    public async Task StartAsync(CancellationToken ct)
+    {
+        _listener.Start();
+        _ = Task.Run(async () =>
+        {
+            _listening.TrySetResult();
+            try
+            {
+                while (!_cts.IsCancellationRequested)
+                {
+                    using var client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                    await using var stream = client.GetStream();
+
+                    // Drain the request headers (best-effort) before replying.
+                    var buffer = new byte[4096];
+                    try
+                    {
+                        using var readCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+                        _ = await stream.ReadAsync(buffer, readCts.Token);
+                    }
+                    catch (OperationCanceledException) { }
+
+                    var bodyBytes = Encoding.UTF8.GetBytes(_body);
+                    var reasonPhrase = _status.ToString();
+                    var header = Encoding.ASCII.GetBytes(
+                        $"HTTP/1.1 {(int)_status} {reasonPhrase}\r\n"
+                            + $"Content-Length: {bodyBytes.Length}\r\n"
+                            + $"Content-Type: {_contentType}\r\n"
+                            + "Connection: close\r\n"
+                            + "\r\n"
+                    );
+                    await stream.WriteAsync(header, _cts.Token);
+                    if (bodyBytes.Length > 0)
+                        await stream.WriteAsync(bodyBytes, _cts.Token);
+                    await stream.FlushAsync(_cts.Token);
+                }
+            }
+            catch (OperationCanceledException) { /* expected on dispose */
+            }
+            catch (ObjectDisposedException) { /* expected on dispose */
+            }
+            catch (IOException) { /* client disconnected */
+            }
+        });
+
+        await _listening.Task.WaitAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _listener.Stop();
+        _cts.Dispose();
+    }
+}

--- a/base/Configuration/tests/Annium.Configuration.Tests.Lib/StaticResponseTcpListener.cs
+++ b/base/Configuration/tests/Annium.Configuration.Tests.Lib/StaticResponseTcpListener.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -12,16 +11,11 @@ namespace Annium.Configuration.Tests.Lib;
 /// Local TCP listener that returns a fixed HTTP status code + body for any incoming request.
 /// Used to drive non-2xx response paths without bringing up a full HTTP server.
 /// </summary>
-public sealed class StaticResponseTcpListener : IAsyncDisposable
+public sealed class StaticResponseTcpListener : TcpListenerBase
 {
-    private readonly TcpListener _listener;
-    private readonly CancellationTokenSource _cts = new();
     private readonly HttpStatusCode _status;
     private readonly string _body;
-    private readonly string _resourcePath;
     private readonly string _contentType;
-    private readonly TaskCompletionSource _listening = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private Task? _acceptLoop;
 
     /// <summary>
     /// Initializes a new instance.
@@ -36,102 +30,44 @@ public sealed class StaticResponseTcpListener : IAsyncDisposable
         string resourcePath,
         string contentType = "application/json"
     )
+        : base(resourcePath)
     {
         _status = status;
         _body = body;
-        _resourcePath = resourcePath;
         _contentType = contentType;
-        _listener = new TcpListener(IPAddress.Loopback, 0);
-    }
-
-    /// <summary>
-    /// The loopback URI exposed by this listener.
-    /// </summary>
-    public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/{_resourcePath}");
-
-    /// <summary>
-    /// Starts the listener and awaits the ready signal. The accept loop runs as a
-    /// tracked <see cref="Task"/> stored in a private field so <see cref="DisposeAsync"/>
-    /// can await its completion — propagating any unexpected exception instead of swallowing it.
-    /// </summary>
-    public async Task StartAsync(CancellationToken ct)
-    {
-        _listener.Start();
-        _acceptLoop = Task.Run(async () =>
-        {
-            _listening.TrySetResult();
-            try
-            {
-                while (!_cts.IsCancellationRequested)
-                {
-                    using var client = await _listener.AcceptTcpClientAsync(_cts.Token);
-                    await using var stream = client.GetStream();
-
-                    // Drain the request headers (best-effort) before replying.
-                    var buffer = new byte[4096];
-                    try
-                    {
-                        using var readCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
-                        _ = await stream.ReadAsync(buffer, readCts.Token);
-                    }
-                    catch (OperationCanceledException)
-                    { /* best-effort header drain timed out; proceed to write response */
-                    }
-
-                    var bodyBytes = Encoding.UTF8.GetBytes(_body);
-                    var reasonPhrase = _status.ToString();
-                    var header = Encoding.ASCII.GetBytes(
-                        $"HTTP/1.1 {(int)_status} {reasonPhrase}\r\n"
-                            + $"Content-Length: {bodyBytes.Length}\r\n"
-                            + $"Content-Type: {_contentType}\r\n"
-                            + "Connection: close\r\n"
-                            + "\r\n"
-                    );
-                    await stream.WriteAsync(header, _cts.Token);
-                    if (bodyBytes.Length > 0)
-                        await stream.WriteAsync(bodyBytes, _cts.Token);
-                    await stream.FlushAsync(_cts.Token);
-                }
-            }
-            catch (OperationCanceledException)
-            { /* expected on dispose */
-            }
-            catch (ObjectDisposedException)
-            { /* expected on dispose */
-            }
-            catch (IOException)
-            { /* client disconnected */
-            }
-        });
-
-        await _listening.Task.WaitAsync(ct);
     }
 
     /// <inheritdoc />
-    public async ValueTask DisposeAsync()
+    protected override async ValueTask HandleClientAsync(TcpClient client, CancellationToken ct)
     {
-        await _cts.CancelAsync();
-        _listener.Stop();
-        if (_acceptLoop is not null)
+        using (client)
         {
+            await using var stream = client.GetStream();
+
+            // Drain the request headers (best-effort) before replying.
+            var buffer = new byte[4096];
             try
             {
-                // VSTHRD003: the accept-loop Task is started in StartAsync above (same instance, same context)
-                // and Cancel + Stop guarantee its termination before this await — safe to await directly.
-#pragma warning disable VSTHRD003
-                await _acceptLoop;
-#pragma warning restore VSTHRD003
+                using var readCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+                _ = await stream.ReadAsync(buffer, readCts.Token);
             }
             catch (OperationCanceledException)
-            { /* expected on cancel */
+            { /* best-effort header drain timed out; proceed to write response */
             }
-            catch (ObjectDisposedException)
-            { /* expected on listener.Stop */
-            }
-            catch (IOException)
-            { /* client disconnected during dispose */
-            }
+
+            var bodyBytes = Encoding.UTF8.GetBytes(_body);
+            var reasonPhrase = _status.ToString();
+            var header = Encoding.ASCII.GetBytes(
+                $"HTTP/1.1 {(int)_status} {reasonPhrase}\r\n"
+                    + $"Content-Length: {bodyBytes.Length}\r\n"
+                    + $"Content-Type: {_contentType}\r\n"
+                    + "Connection: close\r\n"
+                    + "\r\n"
+            );
+            await stream.WriteAsync(header, ct);
+            if (bodyBytes.Length > 0)
+                await stream.WriteAsync(bodyBytes, ct);
+            await stream.FlushAsync(ct);
         }
-        _cts.Dispose();
     }
 }

--- a/base/Configuration/tests/Annium.Configuration.Tests.Lib/StaticResponseTcpListener.cs
+++ b/base/Configuration/tests/Annium.Configuration.Tests.Lib/StaticResponseTcpListener.cs
@@ -12,7 +12,7 @@ namespace Annium.Configuration.Tests.Lib;
 /// Local TCP listener that returns a fixed HTTP status code + body for any incoming request.
 /// Used to drive non-2xx response paths without bringing up a full HTTP server.
 /// </summary>
-public sealed class StaticResponseTcpListener : IDisposable
+public sealed class StaticResponseTcpListener : IAsyncDisposable
 {
     private readonly TcpListener _listener;
     private readonly CancellationTokenSource _cts = new();
@@ -21,6 +21,7 @@ public sealed class StaticResponseTcpListener : IDisposable
     private readonly string _resourcePath;
     private readonly string _contentType;
     private readonly TaskCompletionSource _listening = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private Task? _acceptLoop;
 
     /// <summary>
     /// Initializes a new instance.
@@ -49,12 +50,14 @@ public sealed class StaticResponseTcpListener : IDisposable
     public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/{_resourcePath}");
 
     /// <summary>
-    /// Starts the listener and awaits the ready signal.
+    /// Starts the listener and awaits the ready signal. The accept loop runs as a
+    /// tracked <see cref="Task"/> stored in a private field so <see cref="DisposeAsync"/>
+    /// can await its completion — propagating any unexpected exception instead of swallowing it.
     /// </summary>
     public async Task StartAsync(CancellationToken ct)
     {
         _listener.Start();
-        _ = Task.Run(async () =>
+        _acceptLoop = Task.Run(async () =>
         {
             _listening.TrySetResult();
             try
@@ -105,10 +108,30 @@ public sealed class StaticResponseTcpListener : IDisposable
     }
 
     /// <inheritdoc />
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
-        _cts.Cancel();
+        await _cts.CancelAsync();
         _listener.Stop();
+        if (_acceptLoop is not null)
+        {
+            try
+            {
+                // VSTHRD003: the accept-loop Task is started in StartAsync above (same instance, same context)
+                // and Cancel + Stop guarantee its termination before this await — safe to await directly.
+#pragma warning disable VSTHRD003
+                await _acceptLoop;
+#pragma warning restore VSTHRD003
+            }
+            catch (OperationCanceledException)
+            { /* expected on cancel */
+            }
+            catch (ObjectDisposedException)
+            { /* expected on listener.Stop */
+            }
+            catch (IOException)
+            { /* client disconnected during dispose */
+            }
+        }
         _cts.Dispose();
     }
 }

--- a/base/Configuration/tests/Annium.Configuration.Tests.Lib/StaticResponseTcpListener.cs
+++ b/base/Configuration/tests/Annium.Configuration.Tests.Lib/StaticResponseTcpListener.cs
@@ -71,7 +71,9 @@ public sealed class StaticResponseTcpListener : IDisposable
                         using var readCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
                         _ = await stream.ReadAsync(buffer, readCts.Token);
                     }
-                    catch (OperationCanceledException) { }
+                    catch (OperationCanceledException)
+                    { /* best-effort header drain timed out; proceed to write response */
+                    }
 
                     var bodyBytes = Encoding.UTF8.GetBytes(_body);
                     var reasonPhrase = _status.ToString();
@@ -88,11 +90,14 @@ public sealed class StaticResponseTcpListener : IDisposable
                     await stream.FlushAsync(_cts.Token);
                 }
             }
-            catch (OperationCanceledException) { /* expected on dispose */
+            catch (OperationCanceledException)
+            { /* expected on dispose */
             }
-            catch (ObjectDisposedException) { /* expected on dispose */
+            catch (ObjectDisposedException)
+            { /* expected on dispose */
             }
-            catch (IOException) { /* client disconnected */
+            catch (IOException)
+            { /* client disconnected */
             }
         });
 

--- a/base/Configuration/tests/Annium.Configuration.Tests.Lib/TcpListenerBase.cs
+++ b/base/Configuration/tests/Annium.Configuration.Tests.Lib/TcpListenerBase.cs
@@ -1,0 +1,119 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Annium.Configuration.Tests.Lib;
+
+/// <summary>
+/// Base for local loopback TCP listeners used in tests. Owns the listener socket, the
+/// accept-loop lifecycle, and deterministic teardown; subclasses supply only the
+/// per-connection handling via <see cref="HandleClientAsync"/> and optional cleanup via
+/// <see cref="CleanupAsync"/>.
+/// </summary>
+public abstract class TcpListenerBase : IAsyncDisposable
+{
+    private readonly TcpListener _listener;
+    private readonly TaskCompletionSource _listening = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly string _resourcePath;
+    private Task? _acceptLoop;
+
+    /// <summary>
+    /// Cancellation source signalled on dispose. Subclasses observe the token passed to
+    /// <see cref="HandleClientAsync"/>; it is cancelled before the accept loop is torn down.
+    /// </summary>
+    protected CancellationTokenSource Cts { get; } = new();
+
+    /// <summary>
+    /// Initializes a new instance bound to an OS-assigned loopback port.
+    /// </summary>
+    /// <param name="resourcePath">The resource path appended to the listener's URI (e.g. "config.json").</param>
+    protected TcpListenerBase(string resourcePath)
+    {
+        _resourcePath = resourcePath;
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+    }
+
+    /// <summary>
+    /// The loopback URI exposed by this listener.
+    /// </summary>
+    public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/{_resourcePath}");
+
+    /// <summary>
+    /// Starts the listener and awaits the ready signal. The accept loop runs as a
+    /// tracked <see cref="Task"/> stored in a private field so <see cref="DisposeAsync"/>
+    /// can await its completion — propagating any unexpected exception instead of swallowing it.
+    /// </summary>
+    public async Task StartAsync(CancellationToken ct)
+    {
+        _listener.Start();
+        _acceptLoop = Task.Run(async () =>
+        {
+            _listening.TrySetResult();
+            try
+            {
+                while (!Cts.IsCancellationRequested)
+                {
+                    var client = await _listener.AcceptTcpClientAsync(Cts.Token);
+                    await HandleClientAsync(client, Cts.Token);
+                }
+            }
+            catch (OperationCanceledException)
+            { /* expected on dispose */
+            }
+            catch (ObjectDisposedException)
+            { /* expected on dispose */
+            }
+            catch (IOException)
+            { /* client disconnected */
+            }
+        });
+
+        await _listening.Task.WaitAsync(ct);
+    }
+
+    /// <summary>
+    /// Handles a single accepted connection. Implementations own the lifetime of
+    /// <paramref name="client"/> — dispose it when done, or retain it deliberately.
+    /// </summary>
+    /// <param name="client">The accepted TCP client.</param>
+    /// <param name="ct">Token signalled when the listener is disposed.</param>
+    protected abstract ValueTask HandleClientAsync(TcpClient client, CancellationToken ct);
+
+    /// <summary>
+    /// Releases subclass-owned resources after the accept loop has terminated. Called once
+    /// during <see cref="DisposeAsync"/>; the base implementation is a no-op.
+    /// </summary>
+    protected virtual ValueTask CleanupAsync() => ValueTask.CompletedTask;
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await Cts.CancelAsync();
+        _listener.Stop();
+        if (_acceptLoop is not null)
+        {
+            try
+            {
+                // VSTHRD003: the accept-loop Task is started in StartAsync above (same instance, same context)
+                // and Cancel + Stop guarantee its termination before this await — safe to await directly.
+#pragma warning disable VSTHRD003
+                await _acceptLoop;
+#pragma warning restore VSTHRD003
+            }
+            catch (OperationCanceledException)
+            { /* expected on cancel */
+            }
+            catch (ObjectDisposedException)
+            { /* expected on listener.Stop */
+            }
+            catch (IOException)
+            { /* client disconnected during dispose */
+            }
+        }
+        await CleanupAsync();
+        Cts.Dispose();
+    }
+}

--- a/base/Configuration/tests/Annium.Configuration.Tests.Lib/TestContainerFactory.cs
+++ b/base/Configuration/tests/Annium.Configuration.Tests.Lib/TestContainerFactory.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Annium.Core.DependencyInjection;
+using Annium.Core.Mapper;
+using Annium.Core.Runtime;
+using Annium.Logging.Shared;
+
+namespace Annium.Configuration.Tests.Lib;
+
+/// <summary>
+/// Builds a minimal <see cref="ServiceContainer"/> with the registrations
+/// <c>AddConfigurationAsync</c> needs (runtime types + time + logging + mapper).
+/// </summary>
+public static class TestContainerFactory
+{
+    /// <summary>
+    /// Creates a service container with runtime / time / logging / mapper registrations
+    /// suitable for configuration tests. The runtime scans the calling test assembly.
+    /// </summary>
+    public static ServiceContainer Create()
+    {
+        var container = new ServiceContainer();
+        container.AddRuntime(Assembly.GetCallingAssembly());
+        container.AddTime().WithRealTime().SetDefault();
+        container.AddLogging();
+        container.AddMapper(autoload: false);
+        return container;
+    }
+}

--- a/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
@@ -57,7 +57,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task LoadAsync_Non2xxResponse_ThrowsHttpRequestException()
     {
-        using var stub = new StaticResponseTcpListener(
+        await using var stub = new StaticResponseTcpListener(
             HttpStatusCode.InternalServerError,
             "value: ok",
             "config.yaml",
@@ -81,7 +81,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task LoadAsync_CtCancelled_ThrowsOperationCanceledException()
     {
-        using var stub = new HangingTcpListener("config.yaml");
+        await using var stub = new HangingTcpListener("config.yaml");
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         using var cts = new CancellationTokenSource();
@@ -105,7 +105,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task BuildAsync_AddRemoteYaml_TimeoutNotOptional_Throws()
     {
-        using var stub = new HangingTcpListener("config.yaml");
+        await using var stub = new HangingTcpListener("config.yaml");
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();
@@ -126,7 +126,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task BuildAsync_AddRemoteYaml_TimeoutOptional_Succeeds()
     {
-        using var stub = new HangingTcpListener("config.yaml");
+        await using var stub = new HangingTcpListener("config.yaml");
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();

--- a/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
@@ -136,4 +136,30 @@ public class BuildAsyncTests
 
         container.Get().Count.Is(0);
     }
+
+    /// <summary>
+    /// A remote source returning 200 OK with a valid YAML body parses and flattens the
+    /// payload into the container — the success branch of <c>RemoteConfigurationSourceBase.LoadAsync</c>
+    /// for the YAML flavour (mirror of the Json <c>LoadAsync_SuccessResponse_LoadsRemoteData</c> test).
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_SuccessResponse_LoadsRemoteData()
+    {
+        await using var stub = new StaticResponseTcpListener(
+            HttpStatusCode.OK,
+            "plain: 42\nsection:\n  value: ok\n",
+            "config.yaml",
+            contentType: "application/x-yaml"
+        );
+        await stub.StartAsync(TestContext.Current.CancellationToken);
+
+        var container = ConfigurationFactory.CreateContainer();
+        container.AddRemoteYaml(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(5));
+
+        await container.BuildAsync(TestContext.Current.CancellationToken);
+
+        var data = container.Get();
+        data.At(new[] { "plain" }).Is("42");
+        data.At(new[] { "section", "value" }).Is("ok");
+    }
 }

--- a/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
@@ -11,37 +11,24 @@ using Annium.Configuration.Abstractions;
 using Annium.Testing;
 using Xunit;
 
-namespace Annium.Configuration.Json.Tests;
+namespace Annium.Configuration.Yaml.Tests;
 
 /// <summary>
-/// Tests for the deferred-source build pipeline — JSON file + remote sources +
+/// Tests for the deferred-source build pipeline — YAML file + remote sources +
 /// optional / non-optional semantics through <see cref="Abstractions.ConfigurationContainerExtensions.BuildAsync"/>.
 /// </summary>
 public class BuildAsyncTests
 {
     /// <summary>
-    /// An empty container (no sources registered) is a no-op for <c>BuildAsync</c>.
-    /// </summary>
-    [Fact]
-    public async Task BuildAsync_NoSources_NoOp()
-    {
-        var container = ConfigurationFactory.CreateContainer();
-
-        await container.BuildAsync(TestContext.Current.CancellationToken);
-
-        container.Get().Count.Is(0);
-    }
-
-    /// <summary>
-    /// Pointing <c>AddJsonFile(optional: false)</c> at a missing file makes <c>BuildAsync</c>
+    /// Pointing <c>AddYamlFile(optional: false)</c> at a missing file makes <c>BuildAsync</c>
     /// throw <see cref="AggregateException"/> wrapping a <see cref="FileNotFoundException"/>.
     /// </summary>
     [Fact]
-    public async Task BuildAsync_AddJsonFile_MissingNotOptional_Throws()
+    public async Task BuildAsync_AddYamlFile_MissingNotOptional_Throws()
     {
         var container = ConfigurationFactory.CreateContainer();
-        var missing = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.json");
-        container.AddJsonFile(missing, optional: false);
+        var missing = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.yaml");
+        container.AddYamlFile(missing, optional: false);
 
         var ex = await Wrap.It(async () => await container.BuildAsync(TestContext.Current.CancellationToken))
             .ThrowsAsync<AggregateException>();
@@ -50,15 +37,15 @@ public class BuildAsyncTests
     }
 
     /// <summary>
-    /// Pointing <c>AddJsonFile(optional: true)</c> at a missing file makes <c>BuildAsync</c>
+    /// Pointing <c>AddYamlFile(optional: true)</c> at a missing file makes <c>BuildAsync</c>
     /// succeed; the missing source contributes no data.
     /// </summary>
     [Fact]
-    public async Task BuildAsync_AddJsonFile_MissingOptional_Succeeds()
+    public async Task BuildAsync_AddYamlFile_MissingOptional_Succeeds()
     {
         var container = ConfigurationFactory.CreateContainer();
-        var missing = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.json");
-        container.AddJsonFile(missing, optional: true);
+        var missing = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.yaml");
+        container.AddYamlFile(missing, optional: true);
 
         await container.BuildAsync(TestContext.Current.CancellationToken);
 
@@ -66,86 +53,17 @@ public class BuildAsyncTests
     }
 
     /// <summary>
-    /// Pointing <c>AddJsonFile</c> at a real file flattens its contents into the container.
-    /// </summary>
-    [Fact]
-    public async Task BuildAsync_AddJsonFile_ExistingFile_Loads()
-    {
-        var jsonFile = Path.GetTempFileName();
-        try
-        {
-            File.WriteAllText(jsonFile, "{\"plain\":42,\"section\":{\"value\":\"ok\"}}");
-            var container = ConfigurationFactory.CreateContainer();
-            container.AddJsonFile(jsonFile);
-
-            await container.BuildAsync(TestContext.Current.CancellationToken);
-
-            var data = container.Get();
-            data.Count.Is(2);
-            data.At(new[] { "plain" }).Is("42");
-            data.At(new[] { "section", "value" }).Is("ok");
-        }
-        finally
-        {
-            File.Delete(jsonFile);
-        }
-    }
-
-    /// <summary>
-    /// A remote source pointed at a stub server that accepts but never responds, with a short
-    /// timeout, makes <c>BuildAsync(optional: false)</c> throw via <see cref="AggregateException"/>.
-    /// The inner is normally <see cref="TimeoutException"/>, but under heavy parallel test load
-    /// the network stack can surface a sibling <see cref="System.Net.Http.HttpRequestException"/>
-    /// with an <see cref="System.IO.IOException"/> inner instead — both denote "remote fetch
-    /// could not complete", which is the spec's behavioral contract for non-optional sources.
-    /// </summary>
-    [Fact]
-    public async Task BuildAsync_AddRemoteJson_TimeoutNotOptional_Throws()
-    {
-        using var stub = new HangingTcpListener();
-        await stub.StartAsync(TestContext.Current.CancellationToken);
-
-        var container = ConfigurationFactory.CreateContainer();
-        container.AddRemoteJson(stub.Uri, optional: false, timeout: TimeSpan.FromMilliseconds(500));
-
-        var ex = await Wrap.It(async () => await container.BuildAsync(TestContext.Current.CancellationToken))
-            .ThrowsAsync<AggregateException>();
-        ex.InnerExceptions.Has(1);
-        var inner = ex.InnerExceptions[0];
-        var isFetchFailure = inner is TimeoutException or HttpRequestException;
-        isFetchFailure.IsTrue($"expected fetch failure; got {inner.GetType().FullName}: {inner.Message}");
-    }
-
-    /// <summary>
-    /// Same stub server + 500ms timeout, but with <c>optional: true</c> — <c>BuildAsync</c> returns
-    /// successfully and the source contributes no data.
-    /// </summary>
-    [Fact]
-    public async Task BuildAsync_AddRemoteJson_TimeoutOptional_Succeeds()
-    {
-        using var stub = new HangingTcpListener();
-        await stub.StartAsync(TestContext.Current.CancellationToken);
-
-        var container = ConfigurationFactory.CreateContainer();
-        container.AddRemoteJson(stub.Uri, optional: true, timeout: TimeSpan.FromMilliseconds(500));
-
-        await container.BuildAsync(TestContext.Current.CancellationToken);
-
-        container.Get().Count.Is(0);
-    }
-
-    /// <summary>
-    /// A remote source pointed at a server returning a non-2xx response surfaces an
+    /// Mirror of the Json test: a remote source returning a non-2xx response surfaces an
     /// <see cref="HttpRequestException"/> wrapped in <see cref="AggregateException"/>.
     /// </summary>
     [Fact]
     public async Task LoadAsync_Non2xxResponse_ThrowsHttpRequestException()
     {
-        using var stub = new StaticResponseTcpListener(HttpStatusCode.InternalServerError, "{}");
+        using var stub = new StaticResponseTcpListener(HttpStatusCode.InternalServerError, "value: ok");
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();
-        container.AddRemoteJson(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(5));
+        container.AddRemoteYaml(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(5));
 
         var ex = await Wrap.It(async () => await container.BuildAsync(TestContext.Current.CancellationToken))
             .ThrowsAsync<AggregateException>();
@@ -154,9 +72,8 @@ public class BuildAsyncTests
     }
 
     /// <summary>
-    /// A pre-cancelled cancellation token surfaces <see cref="OperationCanceledException"/>
-    /// (not <see cref="TimeoutException"/>) so callers can distinguish intentional cancel from
-    /// timeout. Verified against a listener that accepts but never responds.
+    /// Mirror of the Json test: a pre-cancelled CT surfaces <see cref="OperationCanceledException"/>
+    /// (not <see cref="TimeoutException"/>).
     /// </summary>
     [Fact]
     public async Task LoadAsync_CtCancelled_ThrowsOperationCanceledException()
@@ -168,7 +85,7 @@ public class BuildAsyncTests
         await cts.CancelAsync();
 
         var container = ConfigurationFactory.CreateContainer();
-        container.AddRemoteJson(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(30));
+        container.AddRemoteYaml(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(30));
 
         var ex = await Wrap.It(async () => await container.BuildAsync(cts.Token))
             .ThrowsAsync<AggregateException>();
@@ -179,10 +96,8 @@ public class BuildAsyncTests
     }
 
     /// <summary>
-    /// Local TCP listener that accepts connections but never sends a response — used to force
-    /// a deterministic <c>HttpClient</c> timeout trigger regardless of the test host's network
-    /// configuration. Holds strong references to accepted clients so GC can't reap them
-    /// mid-test (which would otherwise close the socket and translate timeout into IO error).
+    /// Local TCP listener that accepts connections but never sends a response. Mirrors the Json
+    /// test helper to keep the YAML coverage symmetric.
     /// </summary>
     private sealed class HangingTcpListener : IDisposable
     {
@@ -196,7 +111,7 @@ public class BuildAsyncTests
             _listener = new TcpListener(IPAddress.Loopback, 0);
         }
 
-        public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/config.json");
+        public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/config.yaml");
 
         public async Task StartAsync(CancellationToken ct)
         {
@@ -209,16 +124,12 @@ public class BuildAsyncTests
                     while (!_cts.IsCancellationRequested)
                     {
                         var client = await _listener.AcceptTcpClientAsync(_cts.Token);
-                        // Hold a strong reference so GC doesn't reap the socket while the test
-                        // is mid-request — otherwise HttpClient sees an IO error, not a timeout.
                         lock (_accepted)
                             _accepted.Add(client);
                     }
                 }
-                catch (OperationCanceledException) { /* expected on dispose */
-                }
-                catch (ObjectDisposedException) { /* expected on dispose */
-                }
+                catch (OperationCanceledException) { }
+                catch (ObjectDisposedException) { }
             });
 
             await _listening.Task.WaitAsync(ct);
@@ -240,7 +151,6 @@ public class BuildAsyncTests
 
     /// <summary>
     /// Local TCP listener that returns a fixed HTTP status code + body for any incoming request.
-    /// Used to drive non-2xx response paths without bringing up a full HTTP server.
     /// </summary>
     private sealed class StaticResponseTcpListener : IDisposable
     {
@@ -257,7 +167,7 @@ public class BuildAsyncTests
             _listener = new TcpListener(IPAddress.Loopback, 0);
         }
 
-        public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/config.json");
+        public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/config.yaml");
 
         public async Task StartAsync(CancellationToken ct)
         {
@@ -272,7 +182,6 @@ public class BuildAsyncTests
                         using var client = await _listener.AcceptTcpClientAsync(_cts.Token);
                         await using var stream = client.GetStream();
 
-                        // Drain the request headers (best-effort) before replying.
                         var buffer = new byte[4096];
                         try
                         {
@@ -286,7 +195,7 @@ public class BuildAsyncTests
                         var header = Encoding.ASCII.GetBytes(
                             $"HTTP/1.1 {(int)_status} {reasonPhrase}\r\n"
                                 + $"Content-Length: {bodyBytes.Length}\r\n"
-                                + "Content-Type: application/json\r\n"
+                                + "Content-Type: application/x-yaml\r\n"
                                 + "Connection: close\r\n"
                                 + "\r\n"
                         );
@@ -296,12 +205,9 @@ public class BuildAsyncTests
                         await stream.FlushAsync(_cts.Token);
                     }
                 }
-                catch (OperationCanceledException) { /* expected on dispose */
-                }
-                catch (ObjectDisposedException) { /* expected on dispose */
-                }
-                catch (IOException) { /* client disconnected */
-                }
+                catch (OperationCanceledException) { }
+                catch (ObjectDisposedException) { }
+                catch (IOException) { }
             });
 
             await _listening.Task.WaitAsync(ct);

--- a/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
@@ -98,6 +98,31 @@ public class BuildAsyncTests
     }
 
     /// <summary>
+    /// Mirror of the Json mid-flight test: a token cancelled WHILE the request is in-flight
+    /// surfaces <see cref="OperationCanceledException"/>, not <see cref="TimeoutException"/> — the
+    /// per-source timeout is long enough that only the caller's cancellation can fire. Exercises
+    /// the <c>!ct.IsCancellationRequested</c> catch filter at the async suspension point.
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_CtCancelledMidFlight_ThrowsOperationCanceledException()
+    {
+        await using var stub = new HangingTcpListener("config.yaml");
+        await stub.StartAsync(TestContext.Current.CancellationToken);
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(500));
+
+        var container = ConfigurationFactory.CreateContainer();
+        container.AddRemoteYaml(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(30));
+
+        var ex = await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<AggregateException>();
+        ex.InnerExceptions.Has(1);
+        var inner = ex.InnerExceptions[0];
+        var isCancel = inner is OperationCanceledException;
+        isCancel.IsTrue($"expected OperationCanceledException; got {inner.GetType().FullName}: {inner.Message}");
+    }
+
+    /// <summary>
     /// Mirror of the Json timeout test: a hanging remote endpoint with <c>optional: false</c>
     /// surfaces a <see cref="TimeoutException"/> or <see cref="HttpRequestException"/> wrapped in
     /// <see cref="AggregateException"/>.

--- a/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
@@ -90,8 +90,7 @@ public class BuildAsyncTests
         var container = ConfigurationFactory.CreateContainer();
         container.AddRemoteYaml(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(30));
 
-        var ex = await Wrap.It(async () => await container.BuildAsync(cts.Token))
-            .ThrowsAsync<AggregateException>();
+        var ex = await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<AggregateException>();
         ex.InnerExceptions.Has(1);
         var inner = ex.InnerExceptions[0];
         var isCancel = inner is OperationCanceledException;

--- a/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
@@ -1,13 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Net.Sockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Annium.Configuration.Abstractions;
+using Annium.Configuration.Tests.Lib;
 using Annium.Testing;
 using Xunit;
 
@@ -59,7 +57,12 @@ public class BuildAsyncTests
     [Fact]
     public async Task LoadAsync_Non2xxResponse_ThrowsHttpRequestException()
     {
-        using var stub = new StaticResponseTcpListener(HttpStatusCode.InternalServerError, "value: ok");
+        using var stub = new StaticResponseTcpListener(
+            HttpStatusCode.InternalServerError,
+            "value: ok",
+            "config.yaml",
+            contentType: "application/x-yaml"
+        );
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();
@@ -78,7 +81,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task LoadAsync_CtCancelled_ThrowsOperationCanceledException()
     {
-        using var stub = new HangingTcpListener();
+        using var stub = new HangingTcpListener("config.yaml");
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         using var cts = new CancellationTokenSource();
@@ -96,128 +99,42 @@ public class BuildAsyncTests
     }
 
     /// <summary>
-    /// Local TCP listener that accepts connections but never sends a response. Mirrors the Json
-    /// test helper to keep the YAML coverage symmetric.
+    /// Mirror of the Json timeout test: a hanging remote endpoint with <c>optional: false</c>
+    /// surfaces a <see cref="TimeoutException"/> or <see cref="HttpRequestException"/> wrapped in
+    /// <see cref="AggregateException"/>.
     /// </summary>
-    private sealed class HangingTcpListener : IDisposable
+    [Fact]
+    public async Task BuildAsync_AddRemoteYaml_TimeoutNotOptional_Throws()
     {
-        private readonly TcpListener _listener;
-        private readonly CancellationTokenSource _cts = new();
-        private readonly List<TcpClient> _accepted = new();
-        private readonly TaskCompletionSource _listening = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var stub = new HangingTcpListener("config.yaml");
+        await stub.StartAsync(TestContext.Current.CancellationToken);
 
-        public HangingTcpListener()
-        {
-            _listener = new TcpListener(IPAddress.Loopback, 0);
-        }
+        var container = ConfigurationFactory.CreateContainer();
+        container.AddRemoteYaml(stub.Uri, optional: false, timeout: TimeSpan.FromMilliseconds(500));
 
-        public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/config.yaml");
-
-        public async Task StartAsync(CancellationToken ct)
-        {
-            _listener.Start();
-            _ = Task.Run(async () =>
-            {
-                _listening.TrySetResult();
-                try
-                {
-                    while (!_cts.IsCancellationRequested)
-                    {
-                        var client = await _listener.AcceptTcpClientAsync(_cts.Token);
-                        lock (_accepted)
-                            _accepted.Add(client);
-                    }
-                }
-                catch (OperationCanceledException) { }
-                catch (ObjectDisposedException) { }
-            });
-
-            await _listening.Task.WaitAsync(ct);
-        }
-
-        public void Dispose()
-        {
-            _cts.Cancel();
-            _listener.Stop();
-            lock (_accepted)
-            {
-                foreach (var c in _accepted)
-                    c.Dispose();
-                _accepted.Clear();
-            }
-            _cts.Dispose();
-        }
+        var ex = await Wrap.It(async () => await container.BuildAsync(TestContext.Current.CancellationToken))
+            .ThrowsAsync<AggregateException>();
+        ex.InnerExceptions.Has(1);
+        var inner = ex.InnerExceptions[0];
+        var isFetchFailure = inner is TimeoutException or HttpRequestException;
+        isFetchFailure.IsTrue($"expected fetch failure; got {inner.GetType().FullName}: {inner.Message}");
     }
 
     /// <summary>
-    /// Local TCP listener that returns a fixed HTTP status code + body for any incoming request.
+    /// Mirror of the Json timeout test: same hanging stub with <c>optional: true</c> succeeds
+    /// and the source contributes no data.
     /// </summary>
-    private sealed class StaticResponseTcpListener : IDisposable
+    [Fact]
+    public async Task BuildAsync_AddRemoteYaml_TimeoutOptional_Succeeds()
     {
-        private readonly TcpListener _listener;
-        private readonly CancellationTokenSource _cts = new();
-        private readonly HttpStatusCode _status;
-        private readonly string _body;
-        private readonly TaskCompletionSource _listening = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var stub = new HangingTcpListener("config.yaml");
+        await stub.StartAsync(TestContext.Current.CancellationToken);
 
-        public StaticResponseTcpListener(HttpStatusCode status, string body)
-        {
-            _status = status;
-            _body = body;
-            _listener = new TcpListener(IPAddress.Loopback, 0);
-        }
+        var container = ConfigurationFactory.CreateContainer();
+        container.AddRemoteYaml(stub.Uri, optional: true, timeout: TimeSpan.FromMilliseconds(500));
 
-        public Uri Uri => new($"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}/config.yaml");
+        await container.BuildAsync(TestContext.Current.CancellationToken);
 
-        public async Task StartAsync(CancellationToken ct)
-        {
-            _listener.Start();
-            _ = Task.Run(async () =>
-            {
-                _listening.TrySetResult();
-                try
-                {
-                    while (!_cts.IsCancellationRequested)
-                    {
-                        using var client = await _listener.AcceptTcpClientAsync(_cts.Token);
-                        await using var stream = client.GetStream();
-
-                        var buffer = new byte[4096];
-                        try
-                        {
-                            using var readCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
-                            _ = await stream.ReadAsync(buffer, readCts.Token);
-                        }
-                        catch (OperationCanceledException) { }
-
-                        var bodyBytes = Encoding.UTF8.GetBytes(_body);
-                        var reasonPhrase = _status.ToString();
-                        var header = Encoding.ASCII.GetBytes(
-                            $"HTTP/1.1 {(int)_status} {reasonPhrase}\r\n"
-                                + $"Content-Length: {bodyBytes.Length}\r\n"
-                                + "Content-Type: application/x-yaml\r\n"
-                                + "Connection: close\r\n"
-                                + "\r\n"
-                        );
-                        await stream.WriteAsync(header, _cts.Token);
-                        if (bodyBytes.Length > 0)
-                            await stream.WriteAsync(bodyBytes, _cts.Token);
-                        await stream.FlushAsync(_cts.Token);
-                    }
-                }
-                catch (OperationCanceledException) { }
-                catch (ObjectDisposedException) { }
-                catch (IOException) { }
-            });
-
-            await _listening.Task.WaitAsync(ct);
-        }
-
-        public void Dispose()
-        {
-            _cts.Cancel();
-            _listener.Stop();
-            _cts.Dispose();
-        }
+        container.Get().Count.Is(0);
     }
 }

--- a/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
@@ -90,11 +90,7 @@ public class BuildAsyncTests
         var container = ConfigurationFactory.CreateContainer();
         container.AddRemoteYaml(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(30));
 
-        var ex = await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<AggregateException>();
-        ex.InnerExceptions.Has(1);
-        var inner = ex.InnerExceptions[0];
-        var isCancel = inner is OperationCanceledException;
-        isCancel.IsTrue($"expected OperationCanceledException; got {inner.GetType().FullName}: {inner.Message}");
+        await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<OperationCanceledException>();
     }
 
     /// <summary>
@@ -115,11 +111,7 @@ public class BuildAsyncTests
         var container = ConfigurationFactory.CreateContainer();
         container.AddRemoteYaml(stub.Uri, optional: false, timeout: TimeSpan.FromSeconds(30));
 
-        var ex = await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<AggregateException>();
-        ex.InnerExceptions.Has(1);
-        var inner = ex.InnerExceptions[0];
-        var isCancel = inner is OperationCanceledException;
-        isCancel.IsTrue($"expected OperationCanceledException; got {inner.GetType().FullName}: {inner.Message}");
+        await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<OperationCanceledException>();
     }
 
     /// <summary>

--- a/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
+++ b/base/Configuration/tests/Annium.Configuration.Yaml.Tests/BuildAsyncTests.cs
@@ -18,6 +18,11 @@ namespace Annium.Configuration.Yaml.Tests;
 public class BuildAsyncTests
 {
     /// <summary>
+    /// Resource name served by the stub TCP listeners in these tests.
+    /// </summary>
+    private const string ResourcePath = "config.yaml";
+
+    /// <summary>
     /// Pointing <c>AddYamlFile(optional: false)</c> at a missing file makes <c>BuildAsync</c>
     /// throw <see cref="AggregateException"/> wrapping a <see cref="FileNotFoundException"/>.
     /// </summary>
@@ -51,6 +56,34 @@ public class BuildAsyncTests
     }
 
     /// <summary>
+    /// Pointing <c>AddYamlFile</c> at a real file flattens its contents into the container
+    /// (mirror of the Json existing-file test — exercises the YamlFileSource happy path through
+    /// the BuildAsync pipeline, not just the provider).
+    /// </summary>
+    [Fact]
+    public async Task BuildAsync_AddYamlFile_ExistingFile_Loads()
+    {
+        var yamlFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(yamlFile, "plain: 42\nsection:\n  value: ok\n");
+            var container = ConfigurationFactory.CreateContainer();
+            container.AddYamlFile(yamlFile);
+
+            await container.BuildAsync(TestContext.Current.CancellationToken);
+
+            var data = container.Get();
+            data.Count.Is(2);
+            data.At(new[] { "plain" }).Is("42");
+            data.At(new[] { "section", "value" }).Is("ok");
+        }
+        finally
+        {
+            File.Delete(yamlFile);
+        }
+    }
+
+    /// <summary>
     /// Mirror of the Json test: a remote source returning a non-2xx response surfaces an
     /// <see cref="HttpRequestException"/> wrapped in <see cref="AggregateException"/>.
     /// </summary>
@@ -60,7 +93,7 @@ public class BuildAsyncTests
         await using var stub = new StaticResponseTcpListener(
             HttpStatusCode.InternalServerError,
             "value: ok",
-            "config.yaml",
+            ResourcePath,
             contentType: "application/x-yaml"
         );
         await stub.StartAsync(TestContext.Current.CancellationToken);
@@ -81,7 +114,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task LoadAsync_CtCancelled_ThrowsOperationCanceledException()
     {
-        await using var stub = new HangingTcpListener("config.yaml");
+        await using var stub = new HangingTcpListener(ResourcePath);
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         using var cts = new CancellationTokenSource();
@@ -102,7 +135,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task LoadAsync_CtCancelledMidFlight_ThrowsOperationCanceledException()
     {
-        await using var stub = new HangingTcpListener("config.yaml");
+        await using var stub = new HangingTcpListener(ResourcePath);
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         using var cts = new CancellationTokenSource();
@@ -115,6 +148,27 @@ public class BuildAsyncTests
     }
 
     /// <summary>
+    /// An OPTIONAL remote source whose token is cancelled mid-flight must still surface
+    /// <see cref="OperationCanceledException"/> — caller cancellation is never silenced by the
+    /// <c>Optional</c> flag (only load failures like timeout are). Covers the optional × mid-flight
+    /// quadrant of the cancellation matrix.
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_OptionalCtCancelledMidFlight_ThrowsOperationCanceledException()
+    {
+        await using var stub = new HangingTcpListener(ResourcePath);
+        await stub.StartAsync(TestContext.Current.CancellationToken);
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(500));
+
+        var container = ConfigurationFactory.CreateContainer();
+        container.AddRemoteYaml(stub.Uri, optional: true, timeout: TimeSpan.FromSeconds(30));
+
+        await Wrap.It(async () => await container.BuildAsync(cts.Token)).ThrowsAsync<OperationCanceledException>();
+    }
+
+    /// <summary>
     /// Mirror of the Json timeout test: a hanging remote endpoint with <c>optional: false</c>
     /// surfaces a <see cref="TimeoutException"/> or <see cref="HttpRequestException"/> wrapped in
     /// <see cref="AggregateException"/>.
@@ -122,7 +176,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task BuildAsync_AddRemoteYaml_TimeoutNotOptional_Throws()
     {
-        await using var stub = new HangingTcpListener("config.yaml");
+        await using var stub = new HangingTcpListener(ResourcePath);
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();
@@ -143,7 +197,7 @@ public class BuildAsyncTests
     [Fact]
     public async Task BuildAsync_AddRemoteYaml_TimeoutOptional_Succeeds()
     {
-        await using var stub = new HangingTcpListener("config.yaml");
+        await using var stub = new HangingTcpListener(ResourcePath);
         await stub.StartAsync(TestContext.Current.CancellationToken);
 
         var container = ConfigurationFactory.CreateContainer();
@@ -165,7 +219,7 @@ public class BuildAsyncTests
         await using var stub = new StaticResponseTcpListener(
             HttpStatusCode.OK,
             "plain: 42\nsection:\n  value: ok\n",
-            "config.yaml",
+            ResourcePath,
             contentType: "application/x-yaml"
         );
         await stub.StartAsync(TestContext.Current.CancellationToken);

--- a/base/Configuration/tests/Annium.Configuration.Yaml.Tests/YamlConfigurationProviderTest.cs
+++ b/base/Configuration/tests/Annium.Configuration.Yaml.Tests/YamlConfigurationProviderTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -74,7 +75,8 @@ public class YamlConfigurationProviderTest : TestBase
         result.IsNotDefault();
         result.Flag.IsTrue();
         result.Plain.Is(7);
-        // result.Nullable.Is(3);
+        result.Nullable.IsNotDefault();
+        result.Nullable.Value.Is(3m);
         result.Array.SequenceEqual(new[] { 4, 7 }).IsTrue();
         result.Matrix.Has(2);
         result.Matrix.At(0).SequenceEqual(new[] { 3, 2 }).IsTrue();
@@ -93,5 +95,81 @@ public class YamlConfigurationProviderTest : TestBase
         result.Abstract.As<ConfigTwo>().Value.Is(10);
         result.Abstract.IsEqual(nested);
         nested.Is(new ConfigTwo { Value = 10 });
+    }
+
+    /// <summary>
+    /// An empty YAML document (no top-level node) yields an empty configuration container.
+    /// </summary>
+    [Fact]
+    public async Task Read_EmptyYamlDocument_ReturnsEmptyData()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, string.Empty);
+            var container = ConfigurationFactory.CreateContainer();
+            container.AddYamlFile(path, optional: false);
+
+            await container.BuildAsync(TestContext.Current.CancellationToken);
+
+            container.Get().Count.Is(0);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// A YAML document whose root is a scalar (e.g. <c>42</c>) is invalid for configuration —
+    /// the provider throws <see cref="InvalidOperationException"/> wrapped in <see cref="AggregateException"/>.
+    /// </summary>
+    [Fact]
+    public async Task Read_NonMappingRoot_ThrowsInvalidOperationException()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "42");
+            var container = ConfigurationFactory.CreateContainer();
+            container.AddYamlFile(path, optional: false);
+
+            var ex = await Wrap.It(async () => await container.BuildAsync(TestContext.Current.CancellationToken))
+                .ThrowsAsync<AggregateException>();
+            ex.InnerExceptions.Has(1);
+            ex.InnerExceptions[0].As<InvalidOperationException>();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// A YAML document where a mapping key is itself a mapping node (complex key syntax,
+    /// <c>? { a: 1 } : value</c>) triggers the non-scalar-key guard, surfacing
+    /// <see cref="InvalidOperationException"/>.
+    /// </summary>
+    [Fact]
+    public async Task Read_NonScalarMappingKey_ThrowsInvalidOperationException()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            // YAML 1.2 explicit-key form: "? mapping" makes the key itself a mapping node.
+            File.WriteAllText(path, "? { a: 1 }\n: value\n");
+            var container = ConfigurationFactory.CreateContainer();
+            container.AddYamlFile(path, optional: false);
+
+            var ex = await Wrap.It(async () => await container.BuildAsync(TestContext.Current.CancellationToken))
+                .ThrowsAsync<AggregateException>();
+            ex.InnerExceptions.Has(1);
+            var inner = ex.InnerExceptions[0].As<InvalidOperationException>();
+            inner.Message.Contains("scalar").IsTrue($"expected message mentioning 'scalar'; got: {inner.Message}");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 }


### PR DESCRIPTION
- ObjectConfigurationProvider: ConcurrentDictionary for Helper caches (B1)
- ConfigurationProcessor: throw on null Process<T> result (B2)
- YamlConfigurationProvider: guard all 4 unguarded node casts (B3)
- ConfigurationContainer: internal sealed + ConfigurationFactory (D1)
- Config.cs Tests.Lib: ctor XML docs (D2)
- BuildAsyncTests: TaskCompletionSource ready-signal vs Task.Delay (D3)
- Extract RemoteConfigurationSourceBase + FileConfigurationSourceBase (R1, R2, R3)
- Add 11 test cases closing remote / cmdline / processor / KeyComparer / JSON / nullable / sync gaps (T1-T11)

Refs: kb/reviews/base/2026.05/2026.05.21-configuration.md