### PR TITLE
refactor(annium): return ValueTask from async test and threading APIs

### DIFF
--- a/base/Annium/src/Annium.Testing/DelegateExtensions.cs
+++ b/base/Annium/src/Annium.Testing/DelegateExtensions.cs
@@ -37,7 +37,7 @@ public static class DelegateExtensions
     /// <param name="action">The wrapped asynchronous ValueTask action to execute.</param>
     /// <returns>The thrown exception.</returns>
     /// <exception cref="AssertionFailedException">Thrown when the action does not throw the expected exception.</exception>
-    public static async Task<TException> ThrowsAsync<TException>(this WrappedValueTaskAction action)
+    public static async ValueTask<TException> ThrowsAsync<TException>(this WrappedValueTaskAction action)
         where TException : Exception
     {
         try

--- a/base/Annium/src/Annium.Testing/ExceptionExtensions.cs
+++ b/base/Annium/src/Annium.Testing/ExceptionExtensions.cs
@@ -98,18 +98,15 @@ public static class ExceptionExtensions
     /// <param name="messageEx">The expression that produced the message.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the original exception.</returns>
     /// <exception cref="AssertionFailedException">Thrown when the exception message does not contain the specified text.</exception>
-    public static async Task<T> ReportsAsync<T>(
-        this Task<T> value,
+    public static async ValueTask<T> ReportsAsync<T>(
+        this ValueTask<T> value,
         string message,
         [CallerArgumentExpression(nameof(value))] string valueEx = "",
         [CallerArgumentExpression(nameof(message))] string messageEx = ""
     )
         where T : Exception
     {
-        // Awaiting a Task<T> parameter — VSTHRD003 false positive; task provided by caller, not created locally.
-#pragma warning disable VSTHRD003
         var val = await value;
-#pragma warning restore VSTHRD003
 
         if (!val.Message.Contains(message))
             throw new AssertionFailedException(
@@ -129,18 +126,15 @@ public static class ExceptionExtensions
     /// <param name="messagesEx">The expression that produced the messages.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the original exception.</returns>
     /// <exception cref="AssertionFailedException">Thrown when the exception message does not contain all of the specified texts.</exception>
-    public static async Task<T> ReportsAllAsync<T>(
-        this Task<T> value,
+    public static async ValueTask<T> ReportsAllAsync<T>(
+        this ValueTask<T> value,
         string[] messages,
         [CallerArgumentExpression(nameof(value))] string valueEx = "",
         [CallerArgumentExpression(nameof(messages))] string messagesEx = ""
     )
         where T : Exception
     {
-        // Awaiting a Task<T> parameter — VSTHRD003 false positive; task provided by caller, not created locally.
-#pragma warning disable VSTHRD003
         var val = await value;
-#pragma warning restore VSTHRD003
 
         if (!messages.All(val.Message.Contains))
             throw new AssertionFailedException(
@@ -160,18 +154,15 @@ public static class ExceptionExtensions
     /// <param name="messageEx">The expression that produced the message.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the original exception.</returns>
     /// <exception cref="AssertionFailedException">Thrown when the exception message does not exactly match the specified text.</exception>
-    public static async Task<T> ReportsExactlyAsync<T>(
-        this Task<T> value,
+    public static async ValueTask<T> ReportsExactlyAsync<T>(
+        this ValueTask<T> value,
         string message,
         [CallerArgumentExpression(nameof(value))] string valueEx = "",
         [CallerArgumentExpression(nameof(message))] string messageEx = ""
     )
         where T : Exception
     {
-        // Awaiting a Task<T> parameter — VSTHRD003 false positive; task provided by caller, not created locally.
-#pragma warning disable VSTHRD003
         var val = await value;
-#pragma warning restore VSTHRD003
 
         val.Message.Is(
             message,

--- a/base/Annium/src/Annium.Testing/Expect.cs
+++ b/base/Annium/src/Annium.Testing/Expect.cs
@@ -27,7 +27,7 @@ public static class Expect
     /// <param name="ct">The cancellation token to observe.</param>
     /// <param name="pollDelay">The delay in milliseconds between validation attempts.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    public static async Task ToAsync(Action validate, CancellationToken ct, int pollDelay = DefaultPollDelayMs)
+    public static async ValueTask ToAsync(Action validate, CancellationToken ct, int pollDelay = DefaultPollDelayMs)
     {
         await Wait.UntilAsync(
             () =>
@@ -55,7 +55,11 @@ public static class Expect
     /// <param name="ct">The cancellation token to observe.</param>
     /// <param name="pollDelay">The delay in milliseconds between validation attempts.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    public static async Task ToAsync(Func<ValueTask> validate, CancellationToken ct, int pollDelay = DefaultPollDelayMs)
+    public static async ValueTask ToAsync(
+        Func<ValueTask> validate,
+        CancellationToken ct,
+        int pollDelay = DefaultPollDelayMs
+    )
     {
         await Wait.UntilAsync(
             async () =>
@@ -83,7 +87,11 @@ public static class Expect
     /// <param name="ms">The timeout in milliseconds.</param>
     /// <param name="pollDelay">The delay in milliseconds between validation attempts.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    public static async Task ToAsync(Action validate, int ms = DefaultTimeoutMs, int pollDelay = DefaultPollDelayMs)
+    public static async ValueTask ToAsync(
+        Action validate,
+        int ms = DefaultTimeoutMs,
+        int pollDelay = DefaultPollDelayMs
+    )
     {
         using var cts = new CancellationTokenSource(ms);
         await ToAsync(validate, cts.Token, pollDelay);
@@ -96,7 +104,7 @@ public static class Expect
     /// <param name="ms">The timeout in milliseconds.</param>
     /// <param name="pollDelay">The delay in milliseconds between validation attempts.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    public static async Task ToAsync(
+    public static async ValueTask ToAsync(
         Func<ValueTask> validate,
         int ms = DefaultTimeoutMs,
         int pollDelay = DefaultPollDelayMs

--- a/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Class.cs
+++ b/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Class.cs
@@ -15,17 +15,8 @@ public static partial class ResolveGenericArgumentsByImplementationExtension
     /// <param name="type">The class type to resolve arguments for.</param>
     /// <param name="target">The target generic parameter type.</param>
     /// <returns>An array of resolved type arguments, or null if resolution fails.</returns>
-    private static Type[]? ResolveClassArgumentsByGenericParameter(this Type type, Type target)
-    {
-        if (type.TryGetTargetImplementation(target, out var args))
-            return args;
-
-        // as of here:
-        // - type is open generic type with generic parameters
-        // - target is open/defined generic type with/without generic parameters
-
-        return type.CanBeUsedAsParameter(target) ? type.GetGenericArguments() : null;
-    }
+    private static Type[]? ResolveClassArgumentsByGenericParameter(this Type type, Type target) =>
+        type.ResolveArgumentsByGenericParameter(target);
 
     /// <summary>
     /// Resolves generic arguments for a class type when the target is another class type.

--- a/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Helpers.cs
+++ b/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Helpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 
 // ReSharper disable once CheckNamespace
@@ -9,6 +10,47 @@ namespace Annium.Reflection;
 /// </summary>
 public static partial class ResolveGenericArgumentsByImplementationExtension
 {
+    /// <summary>
+    /// Resolves generic arguments by locating the interface on <paramref name="type"/> whose generic
+    /// definition matches the interface <paramref name="target"/>'s, then building args from it. Shared
+    /// by the struct and interface resolvers' interface-target tails.
+    /// </summary>
+    /// <param name="type">The type to resolve arguments for.</param>
+    /// <param name="target">The target interface type.</param>
+    /// <returns>An array of resolved type arguments, or null if no matching interface is implemented.</returns>
+    private static Type[]? ResolveArgumentsByInterfaceImplementation(this Type type, Type target)
+    {
+        // find interface, that is implementation of target's generic definition
+        var targetBase = target.GetGenericTypeDefinition();
+        var implementation = type.GetInterfaces()
+            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == targetBase);
+
+        if (implementation is null)
+            return null;
+
+        // implementation is generic interface type with same base definition, as target
+        return BuildArgs(type, implementation, target);
+    }
+
+    /// <summary>
+    /// Resolves generic arguments when the target is a generic parameter. Shared by the class, interface,
+    /// and struct resolvers, whose logic is identical.
+    /// </summary>
+    /// <param name="type">The type to resolve arguments for.</param>
+    /// <param name="target">The target generic parameter type.</param>
+    /// <returns>An array of resolved type arguments, or null if resolution fails.</returns>
+    private static Type[]? ResolveArgumentsByGenericParameter(this Type type, Type target)
+    {
+        if (type.TryGetTargetImplementation(target, out var args))
+            return args;
+
+        // as of here:
+        // - type is open generic type with generic parameters
+        // - target is open/defined generic type with/without generic parameters
+
+        return type.CanBeUsedAsParameter(target) ? type.GetGenericArguments() : null;
+    }
+
     /// <summary>
     /// Builds generic arguments for a type based on source and target types.
     /// </summary>

--- a/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Interface.cs
+++ b/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Interface.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 
 // ReSharper disable once CheckNamespace
 namespace Annium.Reflection;
@@ -15,17 +14,8 @@ public static partial class ResolveGenericArgumentsByImplementationExtension
     /// <param name="type">The interface type to resolve arguments for.</param>
     /// <param name="target">The target generic parameter type.</param>
     /// <returns>An array of resolved type arguments, or null if resolution fails.</returns>
-    private static Type[]? ResolveInterfaceArgumentsByGenericParameter(this Type type, Type target)
-    {
-        if (type.TryGetTargetImplementation(target, out var args))
-            return args;
-
-        // as of here:
-        // - type is open generic type with generic parameters
-        // - target is open/defined generic type with/without generic parameters
-
-        return type.CanBeUsedAsParameter(target) ? type.GetGenericArguments() : null;
-    }
+    private static Type[]? ResolveInterfaceArgumentsByGenericParameter(this Type type, Type target) =>
+        type.ResolveArgumentsByGenericParameter(target);
 
     /// <summary>
     /// Resolves generic arguments for an interface type when the target is another interface type.
@@ -48,15 +38,6 @@ public static partial class ResolveGenericArgumentsByImplementationExtension
         if (type.GetGenericTypeDefinition() == target.GetGenericTypeDefinition())
             return BuildArgs(type, type, target);
 
-        // find interface, that is implementation of target's generic definition
-        var targetBase = target.GetGenericTypeDefinition();
-        var implementation = type.GetInterfaces()
-            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == targetBase);
-
-        if (implementation is null)
-            return null;
-
-        // implementation is generic interface type with same base definition, as target
-        return BuildArgs(type, implementation, target);
+        return type.ResolveArgumentsByInterfaceImplementation(target);
     }
 }

--- a/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Main.cs
+++ b/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Main.cs
@@ -45,9 +45,8 @@ public static partial class ResolveGenericArgumentsByImplementationExtension
         target switch
         {
             { IsGenericParameter: true } => type.ResolveGenericParameterArgumentsByGenericParameter(target),
-            { IsClass: true } => type.ResolveGenericParameterArgumentsByClass(target),
-            { IsValueType: true } => type.ResolveGenericParameterArgumentsByStruct(target),
-            { IsInterface: true } => type.ResolveGenericParameterArgumentsByInterface(target),
+            { IsClass: true } or { IsValueType: true } or { IsInterface: true } =>
+                type.ResolveGenericParameterArgumentsByConcrete(target),
             _ => throw NotImplementedException(type, target),
         };
 

--- a/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Parameter.cs
+++ b/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Parameter.cs
@@ -46,36 +46,13 @@ public static partial class ResolveGenericArgumentsByImplementationExtension
     }
 
     /// <summary>
-    /// Resolves generic arguments for a generic parameter type when the target is a class type.
+    /// Resolves generic arguments for a generic parameter type when the target is a concrete type
+    /// (class, struct, or interface). The resolution is identical for all three target kinds.
     /// </summary>
     /// <param name="type">The generic parameter type to resolve arguments for.</param>
-    /// <param name="target">The target class type.</param>
+    /// <param name="target">The target type (class, struct, or interface).</param>
     /// <returns>An array containing the resolved type, or null if constraints are not met.</returns>
-    private static Type[]? ResolveGenericParameterArgumentsByClass(this Type type, Type target)
-    {
-        // return target, if all parameter constraints are implemented
-        return target.CanBeUsedAsParameter(type) ? [target] : null;
-    }
-
-    /// <summary>
-    /// Resolves generic arguments for a generic parameter type when the target is a struct type.
-    /// </summary>
-    /// <param name="type">The generic parameter type to resolve arguments for.</param>
-    /// <param name="target">The target struct type.</param>
-    /// <returns>An array containing the resolved type, or null if constraints are not met.</returns>
-    private static Type[]? ResolveGenericParameterArgumentsByStruct(this Type type, Type target)
-    {
-        // return target, if all parameter constraints are implemented
-        return target.CanBeUsedAsParameter(type) ? [target] : null;
-    }
-
-    /// <summary>
-    /// Resolves generic arguments for a generic parameter type when the target is an interface type.
-    /// </summary>
-    /// <param name="type">The generic parameter type to resolve arguments for.</param>
-    /// <param name="target">The target interface type.</param>
-    /// <returns>An array containing the resolved type, or null if constraints are not met.</returns>
-    private static Type[]? ResolveGenericParameterArgumentsByInterface(this Type type, Type target)
+    private static Type[]? ResolveGenericParameterArgumentsByConcrete(this Type type, Type target)
     {
         // return target, if all parameter constraints are implemented
         return target.CanBeUsedAsParameter(type) ? [target] : null;

--- a/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Struct.cs
+++ b/base/Annium/src/Annium/Reflection/Types/ResolveGenericArgumentsByImplementationExtension.Struct.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 
 // ReSharper disable once CheckNamespace
 namespace Annium.Reflection;
@@ -15,17 +14,8 @@ public static partial class ResolveGenericArgumentsByImplementationExtension
     /// <param name="type">The struct type to resolve arguments for.</param>
     /// <param name="target">The target generic parameter type.</param>
     /// <returns>An array of resolved type arguments, or null if resolution fails.</returns>
-    private static Type[]? ResolveStructArgumentsByGenericParameter(this Type type, Type target)
-    {
-        if (type.TryGetTargetImplementation(target, out var args))
-            return args;
-
-        // as of here:
-        // - type is open generic type with generic parameters
-        // - target is open/defined generic type with/without generic parameters
-
-        return type.CanBeUsedAsParameter(target) ? type.GetGenericArguments() : null;
-    }
+    private static Type[]? ResolveStructArgumentsByGenericParameter(this Type type, Type target) =>
+        type.ResolveArgumentsByGenericParameter(target);
 
     /// <summary>
     /// Resolves generic arguments for a struct type when the target is another struct type.
@@ -69,15 +59,6 @@ public static partial class ResolveGenericArgumentsByImplementationExtension
         // - type is open generic type with generic parameters
         // - target is open/defined generic type with/without generic parameters
 
-        // find interface, that is implementation of target's generic definition
-        var targetBase = target.GetGenericTypeDefinition();
-        var implementation = type.GetInterfaces()
-            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == targetBase);
-
-        if (implementation is null)
-            return null;
-
-        // implementation is generic interface type with same base definition, as target
-        return BuildArgs(type, implementation, target);
+        return type.ResolveArgumentsByInterfaceImplementation(target);
     }
 }

--- a/base/Annium/src/Annium/Threading/Channels/ChannelReaderExtensions.cs
+++ b/base/Annium/src/Annium/Threading/Channels/ChannelReaderExtensions.cs
@@ -88,13 +88,17 @@ public static class ChannelReaderExtensions
     /// <param name="ct">A cancellation token that aborts the wait.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static async Task WhenEmptyAsync<T>(
+    public static async ValueTask WhenEmptyAsync<T>(
         this ChannelReader<T> reader,
         int delay = PollingDefaults.PollDelayMs,
         CancellationToken ct = default
     )
     {
-        while (reader.TryPeek(out _))
-            await Task.Delay(delay, ct).ConfigureAwait(false);
+        try
+        {
+            while (reader.TryPeek(out _))
+                await Task.Delay(delay, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException oce) when (oce.CancellationToken == ct) { }
     }
 }

--- a/base/Annium/src/Annium/Threading/Tasks/Wait.cs
+++ b/base/Annium/src/Annium/Threading/Tasks/Wait.cs
@@ -16,7 +16,7 @@ public static class Wait
     /// <param name="ct">Cancellation token.</param>
     /// <param name="pollDelay">The delay at which the condition will be polled, in milliseconds.</param>
     /// <returns>A task that completes when the condition is false or canceled.</returns>
-    public static async Task WhileAsync(
+    public static async ValueTask WhileAsync(
         Func<bool> condition,
         CancellationToken ct,
         int pollDelay = PollingDefaults.PollDelayMs
@@ -37,7 +37,7 @@ public static class Wait
     /// <param name="ms">Timeout in milliseconds.</param>
     /// <param name="pollDelay">The delay at which the condition will be polled, in milliseconds.</param>
     /// <returns>A task that completes when the condition is false or canceled.</returns>
-    public static async Task WhileAsync(Func<bool> condition, int ms, int pollDelay)
+    public static async ValueTask WhileAsync(Func<bool> condition, int ms, int pollDelay)
     {
         using var cts = new CancellationTokenSource(ms);
         await WhileAsync(condition, cts.Token, pollDelay).ConfigureAwait(false);
@@ -49,7 +49,7 @@ public static class Wait
     /// <param name="condition">The condition that will perpetuate the block.</param>
     /// <param name="ms">Timeout in milliseconds.</param>
     /// <returns>A task that completes when the condition is false or canceled.</returns>
-    public static async Task WhileAsync(Func<bool> condition, int ms)
+    public static async ValueTask WhileAsync(Func<bool> condition, int ms)
     {
         using var cts = new CancellationTokenSource(ms);
         await WhileAsync(condition, cts.Token).ConfigureAwait(false);
@@ -60,7 +60,7 @@ public static class Wait
     /// </summary>
     /// <param name="condition">The condition that will perpetuate the block.</param>
     /// <returns>A task that completes when the condition is false or canceled.</returns>
-    public static Task WhileAsync(Func<bool> condition) => WhileAsync(condition, CancellationToken.None);
+    public static ValueTask WhileAsync(Func<bool> condition) => WhileAsync(condition, CancellationToken.None);
 
     /// <summary>
     /// Awaits while the asynchronous condition is true or the task is canceled.
@@ -69,7 +69,7 @@ public static class Wait
     /// <param name="ct">Cancellation token.</param>
     /// <param name="pollDelay">The delay at which the condition will be polled, in milliseconds.</param>
     /// <returns>A task that completes when the condition is false or canceled.</returns>
-    public static async Task WhileAsync(
+    public static async ValueTask WhileAsync(
         Func<ValueTask<bool>> condition,
         CancellationToken ct,
         int pollDelay = PollingDefaults.PollDelayMs
@@ -90,7 +90,7 @@ public static class Wait
     /// <param name="ms">Timeout in milliseconds.</param>
     /// <param name="pollDelay">The delay at which the condition will be polled, in milliseconds.</param>
     /// <returns>A task that completes when the condition is false or canceled.</returns>
-    public static async Task WhileAsync(Func<ValueTask<bool>> condition, int ms, int pollDelay)
+    public static async ValueTask WhileAsync(Func<ValueTask<bool>> condition, int ms, int pollDelay)
     {
         using var cts = new CancellationTokenSource(ms);
         await WhileAsync(condition, cts.Token, pollDelay).ConfigureAwait(false);
@@ -102,7 +102,7 @@ public static class Wait
     /// <param name="condition">The asynchronous condition that will perpetuate the block.</param>
     /// <param name="ms">Timeout in milliseconds.</param>
     /// <returns>A task that completes when the condition is false or canceled.</returns>
-    public static async Task WhileAsync(Func<ValueTask<bool>> condition, int ms)
+    public static async ValueTask WhileAsync(Func<ValueTask<bool>> condition, int ms)
     {
         using var cts = new CancellationTokenSource(ms);
         await WhileAsync(condition, cts.Token).ConfigureAwait(false);
@@ -113,7 +113,8 @@ public static class Wait
     /// </summary>
     /// <param name="condition">The asynchronous condition that will perpetuate the block.</param>
     /// <returns>A task that completes when the condition is false or canceled.</returns>
-    public static Task WhileAsync(Func<ValueTask<bool>> condition) => WhileAsync(condition, CancellationToken.None);
+    public static ValueTask WhileAsync(Func<ValueTask<bool>> condition) =>
+        WhileAsync(condition, CancellationToken.None);
 
     /// <summary>
     /// Awaits until the condition is true or the task is canceled.
@@ -122,7 +123,7 @@ public static class Wait
     /// <param name="ct">Cancellation token.</param>
     /// <param name="pollDelay">The delay at which the condition will be polled, in milliseconds.</param>
     /// <returns>A task that completes when the condition is true or canceled.</returns>
-    public static async Task UntilAsync(
+    public static async ValueTask UntilAsync(
         Func<bool> condition,
         CancellationToken ct,
         int pollDelay = PollingDefaults.PollDelayMs
@@ -143,7 +144,7 @@ public static class Wait
     /// <param name="ms">Timeout in milliseconds.</param>
     /// <param name="pollDelay">The delay at which the condition will be polled, in milliseconds.</param>
     /// <returns>A task that completes when the condition is true or canceled.</returns>
-    public static async Task UntilAsync(Func<bool> condition, int ms, int pollDelay)
+    public static async ValueTask UntilAsync(Func<bool> condition, int ms, int pollDelay)
     {
         using var cts = new CancellationTokenSource(ms);
         await UntilAsync(condition, cts.Token, pollDelay).ConfigureAwait(false);
@@ -155,7 +156,7 @@ public static class Wait
     /// <param name="condition">The condition that will perpetuate the block.</param>
     /// <param name="ms">Timeout in milliseconds.</param>
     /// <returns>A task that completes when the condition is true or canceled.</returns>
-    public static async Task UntilAsync(Func<bool> condition, int ms)
+    public static async ValueTask UntilAsync(Func<bool> condition, int ms)
     {
         using var cts = new CancellationTokenSource(ms);
         await UntilAsync(condition, cts.Token).ConfigureAwait(false);
@@ -166,7 +167,7 @@ public static class Wait
     /// </summary>
     /// <param name="condition">The condition that will perpetuate the block.</param>
     /// <returns>A task that completes when the condition is true or canceled.</returns>
-    public static Task UntilAsync(Func<bool> condition) => UntilAsync(condition, CancellationToken.None);
+    public static ValueTask UntilAsync(Func<bool> condition) => UntilAsync(condition, CancellationToken.None);
 
     /// <summary>
     /// Awaits until the asynchronous condition is true or the task is canceled.
@@ -175,7 +176,7 @@ public static class Wait
     /// <param name="ct">Cancellation token.</param>
     /// <param name="pollDelay">The delay at which the condition will be polled, in milliseconds.</param>
     /// <returns>A task that completes when the condition is true or canceled.</returns>
-    public static async Task UntilAsync(
+    public static async ValueTask UntilAsync(
         Func<ValueTask<bool>> condition,
         CancellationToken ct,
         int pollDelay = PollingDefaults.PollDelayMs
@@ -196,7 +197,7 @@ public static class Wait
     /// <param name="ms">Timeout in milliseconds.</param>
     /// <param name="pollDelay">The delay at which the condition will be polled, in milliseconds.</param>
     /// <returns>A task that completes when the condition is true or canceled.</returns>
-    public static async Task UntilAsync(Func<ValueTask<bool>> condition, int ms, int pollDelay)
+    public static async ValueTask UntilAsync(Func<ValueTask<bool>> condition, int ms, int pollDelay)
     {
         using var cts = new CancellationTokenSource(ms);
         await UntilAsync(condition, cts.Token, pollDelay).ConfigureAwait(false);
@@ -208,7 +209,7 @@ public static class Wait
     /// <param name="condition">The asynchronous condition that will perpetuate the block.</param>
     /// <param name="ms">Timeout in milliseconds.</param>
     /// <returns>A task that completes when the condition is true or canceled.</returns>
-    public static async Task UntilAsync(Func<ValueTask<bool>> condition, int ms)
+    public static async ValueTask UntilAsync(Func<ValueTask<bool>> condition, int ms)
     {
         using var cts = new CancellationTokenSource(ms);
         await UntilAsync(condition, cts.Token).ConfigureAwait(false);
@@ -219,5 +220,6 @@ public static class Wait
     /// </summary>
     /// <param name="condition">The asynchronous condition that will perpetuate the block.</param>
     /// <returns>A task that completes when the condition is true or canceled.</returns>
-    public static Task UntilAsync(Func<ValueTask<bool>> condition) => UntilAsync(condition, CancellationToken.None);
+    public static ValueTask UntilAsync(Func<ValueTask<bool>> condition) =>
+        UntilAsync(condition, CancellationToken.None);
 }

--- a/base/Annium/tests/Annium.Analyzers.Tests/Logging/DynamicLogMessageTemplateAnalyzerTests.cs
+++ b/base/Annium/tests/Annium.Analyzers.Tests/Logging/DynamicLogMessageTemplateAnalyzerTests.cs
@@ -14,14 +14,20 @@ public sealed class DynamicLogMessageTemplateAnalyzerTests
     : CSharpAnalyzerTest<DynamicLogMessageTemplateAnalyzer, DefaultVerifier>
 {
     /// <summary>
+    /// Initializes the test with the shared logging-analyzer reference assemblies.
+    /// </summary>
+    public DynamicLogMessageTemplateAnalyzerTests()
+    {
+        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
+    }
+
+    /// <summary>
     /// Verifies that the analyzer ignores constant log message templates.
     /// </summary>
     /// <returns>True if the analyzer ignores constant templates; otherwise, false.</returns>
     [Fact]
     public async Task ConstantTemplate_Ignores()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         TestCode = """
 using Annium.Logging;
 
@@ -55,8 +61,6 @@ public class Sample : ILogSubject
     [Fact]
     public async Task DynamicTemplate_ShowsWarning()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         TestCode = """
 using Annium.Logging;
 
@@ -80,7 +84,7 @@ public class Sample : ILogSubject
 
         ExpectedDiagnostics.Add(
             new DiagnosticResult(Descriptors.Log0001DynamicLogMessageTemplate.Id, DiagnosticSeverity.Warning)
-                .WithMessage("Call message template is non-constant")
+                .WithMessage(LoggingAnalyzerTestHelpers.DynamicTemplateMessage)
                 .WithSpan(16, 9, 16, 36)
         );
 
@@ -93,8 +97,6 @@ public class Sample : ILogSubject
     [Fact]
     public async Task StringConcatTemplate_ShowsWarning()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         TestCode = """
 using Annium.Logging;
 
@@ -118,7 +120,7 @@ public class Sample : ILogSubject
 
         ExpectedDiagnostics.Add(
             new DiagnosticResult(Descriptors.Log0001DynamicLogMessageTemplate.Id, DiagnosticSeverity.Warning)
-                .WithMessage("Call message template is non-constant")
+                .WithMessage(LoggingAnalyzerTestHelpers.DynamicTemplateMessage)
                 .WithSpan(16, 9, 16, 40)
         );
 

--- a/base/Annium/tests/Annium.Analyzers.Tests/Logging/DynamicLogMessageTemplateCodeFixTests.cs
+++ b/base/Annium/tests/Annium.Analyzers.Tests/Logging/DynamicLogMessageTemplateCodeFixTests.cs
@@ -15,13 +15,19 @@ public sealed class DynamicLogMessageTemplateCodeFixTests
     : CSharpCodeFixTest<DynamicLogMessageTemplateAnalyzer, DynamicLogMessageTemplateCodeFix, DefaultVerifier>
 {
     /// <summary>
+    /// Initializes the test with the shared logging-analyzer reference assemblies.
+    /// </summary>
+    public DynamicLogMessageTemplateCodeFixTests()
+    {
+        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
+    }
+
+    /// <summary>
     /// Single interpolation: <c>$"run for {id}"</c> becomes <c>"run for {id}", id</c>.
     /// </summary>
     [Fact]
     public async Task WhenDynamicTemplate_ConvertsToStaticTemplate()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         TestCode = """
 using Annium.Logging;
 
@@ -45,7 +51,7 @@ public class Sample : ILogSubject
 
         ExpectedDiagnostics.Add(
             new DiagnosticResult(Descriptors.Log0001DynamicLogMessageTemplate.Id, DiagnosticSeverity.Warning)
-                .WithMessage("Call message template is non-constant")
+                .WithMessage(LoggingAnalyzerTestHelpers.DynamicTemplateMessage)
                 .WithSpan(16, 9, 16, 36)
         );
 
@@ -82,8 +88,6 @@ public class Sample : ILogSubject
     [Fact]
     public async Task WhenInterpolationHasAlignment_NoCodeFixRegistered()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         var code = """
 using Annium.Logging;
 
@@ -109,7 +113,7 @@ public class Sample : ILogSubject
 
         ExpectedDiagnostics.Add(
             new DiagnosticResult(Descriptors.Log0001DynamicLogMessageTemplate.Id, DiagnosticSeverity.Warning)
-                .WithMessage("Call message template is non-constant")
+                .WithMessage(LoggingAnalyzerTestHelpers.DynamicTemplateMessage)
                 .WithSpan(16, 9, 16, 36)
         );
 
@@ -127,8 +131,6 @@ public class Sample : ILogSubject
     [Fact]
     public async Task WhenInterpolationHasFormatClause_NoCodeFixRegistered()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         var code = """
 using Annium.Logging;
 
@@ -154,7 +156,7 @@ public class Sample : ILogSubject
 
         ExpectedDiagnostics.Add(
             new DiagnosticResult(Descriptors.Log0001DynamicLogMessageTemplate.Id, DiagnosticSeverity.Warning)
-                .WithMessage("Call message template is non-constant")
+                .WithMessage(LoggingAnalyzerTestHelpers.DynamicTemplateMessage)
                 .WithSpan(16, 9, 16, 36)
         );
 
@@ -172,8 +174,6 @@ public class Sample : ILogSubject
     [Fact]
     public async Task WhenDuplicateIdentifierInTemplate_BothPlaceholdersSuffixed()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         TestCode = """
 using Annium.Logging;
 
@@ -197,7 +197,7 @@ public class Sample : ILogSubject
 
         ExpectedDiagnostics.Add(
             new DiagnosticResult(Descriptors.Log0001DynamicLogMessageTemplate.Id, DiagnosticSeverity.Warning)
-                .WithMessage("Call message template is non-constant")
+                .WithMessage(LoggingAnalyzerTestHelpers.DynamicTemplateMessage)
                 .WithSpan(16, 9, 16, 35)
         );
 

--- a/base/Annium/tests/Annium.Analyzers.Tests/Logging/ExplicitCallerArgumentAnalyzerTests.cs
+++ b/base/Annium/tests/Annium.Analyzers.Tests/Logging/ExplicitCallerArgumentAnalyzerTests.cs
@@ -14,13 +14,19 @@ public sealed class ExplicitCallerArgumentAnalyzerTests
     : CSharpAnalyzerTest<ExplicitCallerArgumentAnalyzer, DefaultVerifier>
 {
     /// <summary>
+    /// Initializes the test with the shared logging-analyzer reference assemblies.
+    /// </summary>
+    public ExplicitCallerArgumentAnalyzerTests()
+    {
+        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
+    }
+
+    /// <summary>
     /// Calls that omit the caller-info parameters should pass through silently.
     /// </summary>
     [Fact]
     public async Task NoExplicitCallerArguments_Ignored()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         TestCode = """
 using System;
 using Annium.Logging;
@@ -65,8 +71,6 @@ public class Sample : ILogSubject
     [Fact]
     public async Task ExceptionOverloadWithStringSecondArg_Reports()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         TestCode = """
 using System;
 using Annium.Logging;
@@ -91,7 +95,7 @@ public class Sample : ILogSubject
 
         ExpectedDiagnostics.Add(
             new DiagnosticResult(Descriptors.Log0002ExplicitCallerArgument.Id, DiagnosticSeverity.Warning)
-                .WithMessage("Argument bound to 'file' overrides a compiler-injected caller-info value")
+                .WithMessage(LoggingAnalyzerTestHelpers.ExplicitCallerFileMessage)
                 .WithSpan(17, 24, 17, 45)
         );
 
@@ -105,8 +109,6 @@ public class Sample : ILogSubject
     [Fact]
     public async Task TrailingPositionalCallerArgument_Reports()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         TestCode = """
 using Annium.Logging;
 
@@ -130,7 +132,7 @@ public class Sample : ILogSubject
 
         ExpectedDiagnostics.Add(
             new DiagnosticResult(Descriptors.Log0002ExplicitCallerArgument.Id, DiagnosticSeverity.Warning)
-                .WithMessage("Argument bound to 'file' overrides a compiler-injected caller-info value")
+                .WithMessage(LoggingAnalyzerTestHelpers.ExplicitCallerFileMessage)
                 .WithSpan(16, 45, 16, 53)
         );
 
@@ -143,8 +145,6 @@ public class Sample : ILogSubject
     [Fact]
     public async Task NamedCallerArgument_Reports()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         TestCode = """
 using Annium.Logging;
 
@@ -168,7 +168,7 @@ public class Sample : ILogSubject
 
         ExpectedDiagnostics.Add(
             new DiagnosticResult(Descriptors.Log0002ExplicitCallerArgument.Id, DiagnosticSeverity.Warning)
-                .WithMessage("Argument bound to 'file' overrides a compiler-injected caller-info value")
+                .WithMessage(LoggingAnalyzerTestHelpers.ExplicitCallerFileMessage)
                 .WithSpan(16, 29, 16, 43)
         );
 

--- a/base/Annium/tests/Annium.Analyzers.Tests/Logging/ExplicitCallerArgumentCodeFixTests.cs
+++ b/base/Annium/tests/Annium.Analyzers.Tests/Logging/ExplicitCallerArgumentCodeFixTests.cs
@@ -14,14 +14,20 @@ public sealed class ExplicitCallerArgumentCodeFixTests
     : CSharpCodeFixTest<ExplicitCallerArgumentAnalyzer, ExplicitCallerArgumentCodeFix, DefaultVerifier>
 {
     /// <summary>
+    /// Initializes the test with the shared logging-analyzer reference assemblies.
+    /// </summary>
+    public ExplicitCallerArgumentCodeFixTests()
+    {
+        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
+    }
+
+    /// <summary>
     /// <c>this.Error(ex, "msg")</c> is rewritten to <c>this.Error("msg: {exception}", ex)</c> so that the
     /// message reaches the templated overload instead of being lost in the file-path slot.
     /// </summary>
     [Fact]
     public async Task ExceptionOverloadWithStringSecondArg_ConvertsToTemplated()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         TestCode = """
 using System;
 using Annium.Logging;
@@ -68,7 +74,7 @@ public class Sample : ILogSubject
 
         ExpectedDiagnostics.Add(
             new DiagnosticResult(Descriptors.Log0002ExplicitCallerArgument.Id, DiagnosticSeverity.Warning)
-                .WithMessage("Argument bound to 'file' overrides a compiler-injected caller-info value")
+                .WithMessage(LoggingAnalyzerTestHelpers.ExplicitCallerFileMessage)
                 .WithSpan(17, 24, 17, 45)
         );
 
@@ -82,8 +88,6 @@ public class Sample : ILogSubject
     [Fact]
     public async Task TrailingPositionalCallerArgument_RemovesArgument()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         TestCode = """
 using Annium.Logging;
 
@@ -128,7 +132,7 @@ public class Sample : ILogSubject
 
         ExpectedDiagnostics.Add(
             new DiagnosticResult(Descriptors.Log0002ExplicitCallerArgument.Id, DiagnosticSeverity.Warning)
-                .WithMessage("Argument bound to 'file' overrides a compiler-injected caller-info value")
+                .WithMessage(LoggingAnalyzerTestHelpers.ExplicitCallerFileMessage)
                 .WithSpan(16, 45, 16, 53)
         );
 
@@ -141,8 +145,6 @@ public class Sample : ILogSubject
     [Fact]
     public async Task NamedCallerArgument_RemovesArgument()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         TestCode = """
 using Annium.Logging;
 
@@ -187,7 +189,7 @@ public class Sample : ILogSubject
 
         ExpectedDiagnostics.Add(
             new DiagnosticResult(Descriptors.Log0002ExplicitCallerArgument.Id, DiagnosticSeverity.Warning)
-                .WithMessage("Argument bound to 'file' overrides a compiler-injected caller-info value")
+                .WithMessage(LoggingAnalyzerTestHelpers.ExplicitCallerFileMessage)
                 .WithSpan(16, 29, 16, 43)
         );
 
@@ -202,8 +204,6 @@ public class Sample : ILogSubject
     [Fact]
     public async Task ExceptionShapeWithNamedCallerArg_FallsBackToRemoveArgument()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         TestCode = """
 using System;
 using Annium.Logging;
@@ -250,7 +250,7 @@ public class Sample : ILogSubject
 
         ExpectedDiagnostics.Add(
             new DiagnosticResult(Descriptors.Log0002ExplicitCallerArgument.Id, DiagnosticSeverity.Warning)
-                .WithMessage("Argument bound to 'file' overrides a compiler-injected caller-info value")
+                .WithMessage(LoggingAnalyzerTestHelpers.ExplicitCallerFileMessage)
                 .WithSpan(17, 24, 17, 38)
                 .WithArguments("file")
         );
@@ -266,8 +266,6 @@ public class Sample : ILogSubject
     [Fact]
     public async Task NonExceptionShapeWithThreeArgs_FallsBackToRemoveArgument()
     {
-        ReferenceAssemblies = LoggingAnalyzerTestHelpers.BuildReferenceAssemblies();
-
         TestCode = """
 using Annium.Logging;
 
@@ -312,7 +310,7 @@ public class Sample : ILogSubject
 
         ExpectedDiagnostics.Add(
             new DiagnosticResult(Descriptors.Log0002ExplicitCallerArgument.Id, DiagnosticSeverity.Warning)
-                .WithMessage("Argument bound to 'file' overrides a compiler-injected caller-info value")
+                .WithMessage(LoggingAnalyzerTestHelpers.ExplicitCallerFileMessage)
                 .WithSpan(16, 46, 16, 54)
                 .WithArguments("file")
         );

--- a/base/Annium/tests/Annium.Analyzers.Tests/Logging/LoggingAnalyzerTestHelpers.cs
+++ b/base/Annium/tests/Annium.Analyzers.Tests/Logging/LoggingAnalyzerTestHelpers.cs
@@ -10,6 +10,17 @@ namespace Annium.Analyzers.Tests.Logging;
 internal static class LoggingAnalyzerTestHelpers
 {
     /// <summary>
+    /// Expected diagnostic message for LOG0001 (dynamic, non-constant log message template).
+    /// </summary>
+    public const string DynamicTemplateMessage = "Call message template is non-constant";
+
+    /// <summary>
+    /// Expected diagnostic message for LOG0002 when the explicit argument is bound to the 'file' caller-info value.
+    /// </summary>
+    public const string ExplicitCallerFileMessage =
+        "Argument bound to 'file' overrides a compiler-injected caller-info value";
+
+    /// <summary>
     /// Builds the reference assemblies set used by every Logging analyzer / code-fix test fixture.
     /// </summary>
     /// <returns>A configured <see cref="ReferenceAssemblies"/> instance.</returns>

--- a/base/Annium/tests/Annium.Testing.Tests/ExceptionExtensionsTests.cs
+++ b/base/Annium/tests/Annium.Testing.Tests/ExceptionExtensionsTests.cs
@@ -1,5 +1,3 @@
-#pragma warning disable VSTHRD003 // Tests legitimately await Task.FromResult to exercise async overloads.
-
 using System;
 using System.Threading.Tasks;
 using Xunit;
@@ -78,7 +76,7 @@ public class ExceptionExtensionsTests
     [Fact]
     public async Task ReportsAsync_Contains_Passes()
     {
-        var task = Task.FromResult(Sample("async fox"));
+        var task = ValueTask.FromResult(Sample("async fox"));
 
         var result = await task.ReportsAsync("fox");
 
@@ -89,7 +87,7 @@ public class ExceptionExtensionsTests
     [Fact]
     public async Task ReportsAsync_DoesNotContain_Throws()
     {
-        var task = Task.FromResult(Sample("hello"));
+        var task = ValueTask.FromResult(Sample("hello"));
 
         await Assert.ThrowsAsync<AssertionFailedException>(async () => await task.ReportsAsync("missing"));
     }
@@ -98,7 +96,7 @@ public class ExceptionExtensionsTests
     [Fact]
     public async Task ReportsAllAsync_AllPresent_Passes()
     {
-        var task = Task.FromResult(Sample("alpha beta gamma"));
+        var task = ValueTask.FromResult(Sample("alpha beta gamma"));
 
         var result = await task.ReportsAllAsync(["alpha", "gamma"]);
 
@@ -109,7 +107,7 @@ public class ExceptionExtensionsTests
     [Fact]
     public async Task ReportsAllAsync_AnyMissing_Throws()
     {
-        var task = Task.FromResult(Sample("alpha beta"));
+        var task = ValueTask.FromResult(Sample("alpha beta"));
 
         await Assert.ThrowsAsync<AssertionFailedException>(async () =>
             await task.ReportsAllAsync(["alpha", "missing"])
@@ -120,7 +118,7 @@ public class ExceptionExtensionsTests
     [Fact]
     public async Task ReportsExactlyAsync_Equal_Passes()
     {
-        var task = Task.FromResult(Sample("exact"));
+        var task = ValueTask.FromResult(Sample("exact"));
 
         var result = await task.ReportsExactlyAsync("exact");
 
@@ -131,7 +129,7 @@ public class ExceptionExtensionsTests
     [Fact]
     public async Task ReportsExactlyAsync_Differs_Throws()
     {
-        var task = Task.FromResult(Sample("close"));
+        var task = ValueTask.FromResult(Sample("close"));
 
         await Assert.ThrowsAsync<AssertionFailedException>(async () => await task.ReportsExactlyAsync("exact"));
     }

--- a/base/Annium/tests/Annium.Tests/AsyncLazyTest.cs
+++ b/base/Annium/tests/Annium.Tests/AsyncLazyTest.cs
@@ -221,9 +221,15 @@ public class AsyncLazyTest
         await cts.CancelAsync();
 
         // act + assert — WaitAsync should observe the pre-cancelled token and throw
-        await Wrap.It(async () => await lazy.GetValueAsync(cts.Token)).ThrowsAsync<OperationCanceledException>();
-
-        // cleanup — release the inner task so the test doesn't leak the gated factory
-        gate.SetCanceled(TestContext.Current.CancellationToken);
+        try
+        {
+            await Wrap.It(async () => await lazy.GetValueAsync(cts.Token)).ThrowsAsync<OperationCanceledException>();
+        }
+        finally
+        {
+            // cleanup — release the inner task so the test doesn't leak the gated factory even if the
+            // assertion above throws
+            gate.TrySetCanceled(TestContext.Current.CancellationToken);
+        }
     }
 }

--- a/base/Annium/tests/Annium.Tests/Collections/Generic/DoubleEdgeQueueTest.cs
+++ b/base/Annium/tests/Annium.Tests/Collections/Generic/DoubleEdgeQueueTest.cs
@@ -174,4 +174,79 @@ public class DoubleEdgeQueueTest
         queue.IsEmpty();
         Wrap.It(() => queue.RemoveLast()).Throws<InvalidOperationException>();
     }
+
+    /// <summary>
+    /// Verifies that constructing from a non-empty IEnumerable with isDirect=true preserves insertion order
+    /// and exposes the correct Count, First, and Last values.
+    /// </summary>
+    [Fact]
+    public void EntriesCtor_NonEmptyDirect_PreservesOrderAndCount()
+    {
+        // arrange & act
+        var queue = new DoubleEdgeQueue<int>(new[] { 10, 20, 30 }, isDirect: true);
+
+        // assert
+        queue.Has(3);
+        queue.First.Is(10);
+        queue.Last.Is(30);
+        queue.ToArray().IsEqual(new[] { 10, 20, 30 });
+    }
+
+    /// <summary>
+    /// Verifies that constructing from a non-empty IEnumerable with isDirect=false preserves the same
+    /// entry order in the underlying list (directionality only affects Add/Remove, not the stored order).
+    /// </summary>
+    [Fact]
+    public void EntriesCtor_NonEmptyReverse_SameStoredOrder()
+    {
+        // arrange & act — reverse mode: AddFirst/AddLast semantics are inverted but the ctor just
+        // copies the IEnumerable directly into a LinkedList, so First/Last reflect insertion order.
+        var queue = new DoubleEdgeQueue<int>(new[] { 10, 20, 30 }, isDirect: false);
+
+        // assert
+        queue.Has(3);
+        queue.First.Is(10);
+        queue.Last.Is(30);
+        queue.ToArray().IsEqual(new[] { 10, 20, 30 });
+    }
+
+    /// <summary>
+    /// Verifies that constructing from an empty IEnumerable yields a queue with Count == 0.
+    /// </summary>
+    [Fact]
+    public void EntriesCtor_EmptyEnumerable_CountIsZero()
+    {
+        // arrange & act
+        var queue = new DoubleEdgeQueue<int>(Array.Empty<int>(), isDirect: true);
+
+        // assert
+        queue.Has(0);
+        queue.IsEmpty();
+    }
+
+    /// <summary>
+    /// Verifies that accessing First on an empty queue throws InvalidOperationException.
+    /// </summary>
+    [Fact]
+    public void First_EmptyQueue_ThrowsInvalidOperationException()
+    {
+        // arrange
+        var queue = new DoubleEdgeQueue<int>(true);
+
+        // act & assert
+        Wrap.It(() => _ = queue.First).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// Verifies that accessing Last on an empty queue throws InvalidOperationException.
+    /// </summary>
+    [Fact]
+    public void Last_EmptyQueue_ThrowsInvalidOperationException()
+    {
+        // arrange
+        var queue = new DoubleEdgeQueue<int>(true);
+
+        // act & assert
+        Wrap.It(() => _ = queue.Last).Throws<InvalidOperationException>();
+    }
 }

--- a/base/Annium/tests/Annium.Tests/Collections/Generic/ExpiringCollectionTest.cs
+++ b/base/Annium/tests/Annium.Tests/Collections/Generic/ExpiringCollectionTest.cs
@@ -28,7 +28,7 @@ public class ExpiringCollectionTest : TestBase
     {
         // arrange
         var (_, timeProvider) = GetTimeTools();
-        var collection = new ExpiringCollection<int>(timeProvider);
+        using var collection = new ExpiringCollection<int>(timeProvider);
         var ttl = Duration.FromSeconds(5);
 
         // act
@@ -48,7 +48,7 @@ public class ExpiringCollectionTest : TestBase
     {
         // arrange
         var (timeManager, timeProvider) = GetTimeTools();
-        var collection = new ExpiringCollection<Guid>(timeProvider);
+        using var collection = new ExpiringCollection<Guid>(timeProvider);
         var value = Guid.NewGuid();
         var ttl = Duration.FromSeconds(5);
         collection.Add(value, ttl);
@@ -75,7 +75,7 @@ public class ExpiringCollectionTest : TestBase
     {
         // arrange
         var (timeManager, timeProvider) = GetTimeTools();
-        var collection = new ExpiringCollection<Guid>(timeProvider);
+        using var collection = new ExpiringCollection<Guid>(timeProvider);
         var value1 = Guid.NewGuid();
         var value2 = Guid.NewGuid();
         var ttl = Duration.FromSeconds(5);
@@ -116,7 +116,7 @@ public class ExpiringCollectionTest : TestBase
     {
         // arrange
         var (_, timeProvider) = GetTimeTools();
-        var collection = new ExpiringCollection<int>(timeProvider);
+        using var collection = new ExpiringCollection<int>(timeProvider);
         var ttl = Duration.FromSeconds(5);
         for (var i = 0; i < 10; i++)
             collection.Add(i, ttl);
@@ -142,7 +142,7 @@ public class ExpiringCollectionTest : TestBase
     {
         // arrange
         var (_, timeProvider) = GetTimeTools();
-        var collection = new ExpiringCollection<int>(timeProvider);
+        using var collection = new ExpiringCollection<int>(timeProvider);
         collection.Add(1, Duration.FromSeconds(5));
 
         // act — dispose twice; second call must be a no-op (idempotent)

--- a/base/Annium/tests/Annium.Tests/Collections/Generic/ExpiringDictionaryTest.cs
+++ b/base/Annium/tests/Annium.Tests/Collections/Generic/ExpiringDictionaryTest.cs
@@ -30,7 +30,7 @@ public class ExpiringDictionaryTest : TestBase
     {
         // arrange
         var (_, timeProvider) = GetTimeTools();
-        var collection = new ExpiringDictionary<int, string>(timeProvider);
+        using var collection = new ExpiringDictionary<int, string>(timeProvider);
         var ttl = Duration.FromSeconds(5);
 
         // act
@@ -50,7 +50,7 @@ public class ExpiringDictionaryTest : TestBase
     {
         // arrange
         var (timeManager, timeProvider) = GetTimeTools();
-        var collection = new ExpiringDictionary<Guid, string>(timeProvider);
+        using var collection = new ExpiringDictionary<Guid, string>(timeProvider);
         var key = Guid.NewGuid();
         var value = "secret";
         var ttl = Duration.FromSeconds(5);
@@ -74,7 +74,7 @@ public class ExpiringDictionaryTest : TestBase
     {
         // arrange
         var (timeManager, timeProvider) = GetTimeTools();
-        var collection = new ExpiringDictionary<Guid, string>(timeProvider);
+        using var collection = new ExpiringDictionary<Guid, string>(timeProvider);
         var key = Guid.NewGuid();
         var value = "secret";
         var ttl = Duration.FromSeconds(5);
@@ -103,7 +103,7 @@ public class ExpiringDictionaryTest : TestBase
     {
         // arrange
         var (timeManager, timeProvider) = GetTimeTools();
-        var collection = new ExpiringDictionary<Guid, string>(timeProvider);
+        using var collection = new ExpiringDictionary<Guid, string>(timeProvider);
         var key = Guid.NewGuid();
         var ttl = Duration.FromSeconds(5);
         collection.Add(key, "secret", ttl);
@@ -126,7 +126,7 @@ public class ExpiringDictionaryTest : TestBase
     {
         // arrange
         var (timeManager, timeProvider) = GetTimeTools();
-        var collection = new ExpiringDictionary<Guid, string>(timeProvider);
+        using var collection = new ExpiringDictionary<Guid, string>(timeProvider);
         var key1 = Guid.NewGuid();
         var key2 = Guid.NewGuid();
         var ttl = Duration.FromSeconds(5);
@@ -152,7 +152,7 @@ public class ExpiringDictionaryTest : TestBase
     {
         // arrange
         var (_, timeProvider) = GetTimeTools();
-        var collection = new ExpiringDictionary<int, string>(timeProvider);
+        using var collection = new ExpiringDictionary<int, string>(timeProvider);
         var ttl = Duration.FromSeconds(5);
         for (var i = 0; i < 10; i++)
             collection.Add(i, $"v:{i}", ttl);
@@ -177,7 +177,7 @@ public class ExpiringDictionaryTest : TestBase
     {
         // arrange
         var (_, timeProvider) = GetTimeTools();
-        var collection = new ExpiringDictionary<int, string>(timeProvider);
+        using var collection = new ExpiringDictionary<int, string>(timeProvider);
         collection.Add(1, "v:1", Duration.FromSeconds(5));
 
         // act — dispose twice; second call must be a no-op (idempotent)
@@ -197,7 +197,7 @@ public class ExpiringDictionaryTest : TestBase
     {
         // arrange
         var (timeManager, timeProvider) = GetTimeTools();
-        var collection = new ExpiringDictionary<Guid, string>(timeProvider);
+        using var collection = new ExpiringDictionary<Guid, string>(timeProvider);
         var key = Guid.NewGuid();
         var ttl = Duration.FromSeconds(5);
         collection.Add(key, "val", ttl);
@@ -222,7 +222,7 @@ public class ExpiringDictionaryTest : TestBase
         // arrange — use a short eviction interval so the background timer fires quickly
         var (timeManager, timeProvider) = GetTimeTools();
         var evictionInterval = TimeSpan.FromMilliseconds(50);
-        var collection = new ExpiringDictionary<int, string>(timeProvider, evictionInterval);
+        using var collection = new ExpiringDictionary<int, string>(timeProvider, evictionInterval);
         var ttl = Duration.FromMilliseconds(30);
 
         collection.Add(1, "a", ttl);

--- a/base/Annium/tests/Annium.Tests/Collections/Generic/FixedIndexedQueueTest.cs
+++ b/base/Annium/tests/Annium.Tests/Collections/Generic/FixedIndexedQueueTest.cs
@@ -113,4 +113,23 @@ public class FixedIndexedQueueTest
         queue[0].Is(1);
         queue[1].Is(2);
     }
+
+    /// <summary>
+    /// Verifies that constructing a FixedIndexedQueue from an empty collection yields Capacity 0 and Count 0,
+    /// and that calling Add on a zero-capacity queue throws IndexOutOfRangeException because the backing
+    /// array has length 0 and the overflow branch unconditionally indexes into it.
+    /// </summary>
+    [Fact]
+    public void Create_EmptyCollection_ZeroCapacityAndAddThrows()
+    {
+        // arrange
+        var queue = new FixedIndexedQueue<int>(Array.Empty<int>());
+
+        // assert — construction
+        queue.Capacity.Is(0);
+        queue.Count.Is(0);
+
+        // assert — Add on a zero-capacity queue writes to _data[_index] on a zero-length array
+        Wrap.It(() => queue.Add(1)).Throws<IndexOutOfRangeException>();
+    }
 }

--- a/base/Annium/tests/Annium.Tests/CopyableTest.cs
+++ b/base/Annium/tests/Annium.Tests/CopyableTest.cs
@@ -41,9 +41,6 @@ public class CopyableTest
         (zx == z).IsTrue();
         zx.W = 10;
         (zx == z).IsFalse();
-        zx.W = 10;
-        (zx == z).IsFalse();
-        zx.Items[0].W = 10;
     }
 
     /// <summary>

--- a/base/Annium/tests/Annium.Tests/DisposableTest.cs
+++ b/base/Annium/tests/Annium.Tests/DisposableTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -568,6 +569,181 @@ public class DisposableTest : TestBase
 
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract — we deliberately check the post-dispose state.
         (reference.Value is null).IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies that when two async teardowns each throw during DisposeAsync, every registered teardown
+    /// still runs (a fault in one does not skip the other), and awaiting the box's DisposeAsync surfaces
+    /// the first fault unwrapped — Task.WhenAll observes both faults, but awaiting it yields the first.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task AsyncDisposable_TwoAsyncTeardownsThrow_AllRunAndFirstFaultSurfaces()
+    {
+        // arrange
+        var box = Disposable.AsyncBox(Logger);
+        var disposed = 0;
+        box += Disposable.Create(() =>
+        {
+            Interlocked.Increment(ref disposed);
+            throw new InvalidOperationException("fault-1");
+        });
+        box += Disposable.Create(() =>
+        {
+            Interlocked.Increment(ref disposed);
+            throw new ArgumentException("fault-2");
+        });
+
+        // act & assert — both teardowns run despite throwing; awaiting Task.WhenAll surfaces the first
+        // fault unwrapped (not an AggregateException)
+        await Wrap.It(async () => await box.DisposeAsync()).ThrowsAsync<InvalidOperationException>();
+        disposed.Is(2);
+    }
+
+    /// <summary>
+    /// Verifies that += with an IEnumerable of IAsyncDisposable registers all items
+    /// and they are all disposed when DisposeAsync is called.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task AsyncDisposable_AddBatchAsyncDisposables_AllDisposed()
+    {
+        // arrange
+        var box = Disposable.AsyncBox(Logger);
+        var calls = 0;
+        var d1 = Disposable.Create(() =>
+        {
+            ++calls;
+            return ValueTask.CompletedTask;
+        });
+        var d2 = Disposable.Create(() =>
+        {
+            ++calls;
+            return ValueTask.CompletedTask;
+        });
+        var d3 = Disposable.Create(() =>
+        {
+            ++calls;
+            return ValueTask.CompletedTask;
+        });
+
+        // act
+        box += (IEnumerable<IAsyncDisposable>)new IAsyncDisposable[] { d1, d2, d3 };
+        await box.DisposeAsync();
+
+        // assert
+        calls.Is(3);
+    }
+
+    /// <summary>
+    /// Verifies that -= with an IEnumerable of IAsyncDisposable removes the specified items
+    /// so they are NOT disposed, while remaining items are disposed.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task AsyncDisposable_RemoveBatchAsyncDisposables_OnlyRemainingDisposed()
+    {
+        // arrange
+        var box = Disposable.AsyncBox(Logger);
+        var calls = 0;
+        var d1 = Disposable.Create(() =>
+        {
+            ++calls;
+            return ValueTask.CompletedTask;
+        });
+        var d2 = Disposable.Create(() =>
+        {
+            ++calls;
+            return ValueTask.CompletedTask;
+        });
+        var d3 = Disposable.Create(() =>
+        {
+            ++calls;
+            return ValueTask.CompletedTask;
+        });
+
+        box += (IEnumerable<IAsyncDisposable>)new IAsyncDisposable[] { d1, d2, d3 };
+
+        // act — remove d1 and d3, leaving only d2
+        box -= (IEnumerable<IAsyncDisposable>)new IAsyncDisposable[] { d1, d3 };
+        await box.DisposeAsync();
+
+        // assert — only d2 was disposed
+        calls.Is(1);
+    }
+
+    /// <summary>
+    /// Verifies that += with an IEnumerable of Func&lt;ValueTask&gt; registers all functions
+    /// and all are invoked when DisposeAsync is called.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task AsyncDisposable_AddBatchAsyncDisposes_AllInvoked()
+    {
+        // arrange
+        var box = Disposable.AsyncBox(Logger);
+        var calls = 0;
+
+        Func<ValueTask> f1 = () =>
+        {
+            ++calls;
+            return ValueTask.CompletedTask;
+        };
+        Func<ValueTask> f2 = () =>
+        {
+            ++calls;
+            return ValueTask.CompletedTask;
+        };
+        Func<ValueTask> f3 = () =>
+        {
+            ++calls;
+            return ValueTask.CompletedTask;
+        };
+
+        // act
+        box += (IEnumerable<Func<ValueTask>>)new Func<ValueTask>[] { f1, f2, f3 };
+        await box.DisposeAsync();
+
+        // assert
+        calls.Is(3);
+    }
+
+    /// <summary>
+    /// Verifies that -= with an IEnumerable of Func&lt;ValueTask&gt; removes the specified functions
+    /// so they are NOT invoked, while remaining functions are still invoked.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task AsyncDisposable_RemoveBatchAsyncDisposes_OnlyRemainingInvoked()
+    {
+        // arrange
+        var box = Disposable.AsyncBox(Logger);
+        var calls = 0;
+
+        Func<ValueTask> f1 = () =>
+        {
+            ++calls;
+            return ValueTask.CompletedTask;
+        };
+        Func<ValueTask> f2 = () =>
+        {
+            ++calls;
+            return ValueTask.CompletedTask;
+        };
+        Func<ValueTask> f3 = () =>
+        {
+            ++calls;
+            return ValueTask.CompletedTask;
+        };
+
+        box += (IEnumerable<Func<ValueTask>>)new Func<ValueTask>[] { f1, f2, f3 };
+
+        // act — remove f1 and f3, leaving only f2
+        box -= (IEnumerable<Func<ValueTask>>)new Func<ValueTask>[] { f1, f3 };
+        await box.DisposeAsync();
+
+        // assert — only f2 was invoked
+        calls.Is(1);
     }
 
     /// <summary>

--- a/base/Annium/tests/Annium.Tests/IdExtensionsTest.cs
+++ b/base/Annium/tests/Annium.Tests/IdExtensionsTest.cs
@@ -17,14 +17,15 @@ public class IdExtensionsTest
         // arrange
         var a = new Sample();
         var b = new Sample();
-        var c = new { };
+        var d = new Sample2();
 
         // assert
         string.IsNullOrWhiteSpace(a.GetId()).IsFalse();
-        a.GetId().Is(a.GetId());
-        a.GetId().Is("1");
+        a.GetId().Is(a.GetId()); // stable per instance
+        a.GetId().IsNot(b.GetId()); // unique per instance
+        a.GetId().Is("1"); // Sample counter starts at 1 (file-local type)
         b.GetId().Is("2");
-        c.GetId().Is("1");
+        d.GetId().Is("1"); // Sample2 has an independent counter — not shared among types
     }
 }
 
@@ -32,3 +33,8 @@ public class IdExtensionsTest
 /// Sample record for testing GetId extension.
 /// </summary>
 file record Sample;
+
+/// <summary>
+/// Second sample record for verifying per-type counter isolation in GetId.
+/// </summary>
+file record Sample2;

--- a/base/Annium/tests/Annium.Tests/Linq/EnumerableExtensionsTest.cs
+++ b/base/Annium/tests/Annium.Tests/Linq/EnumerableExtensionsTest.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Annium.Linq;
 using Annium.Testing;
@@ -123,5 +125,36 @@ public class EnumerableExtensionsTest
         var src = new[] { "a", "b", "c" };
 
         src.Join(", ").Is("a, b, c");
+    }
+
+    /// <summary>
+    /// ToSortedList with unique keys returns a SortedList whose keys are in ascending order
+    /// and whose values correspond to the source elements.
+    /// </summary>
+    [Fact]
+    public void ToSortedList_UniqueKeys_ReturnsSortedList()
+    {
+        // arrange — intentionally out of order so that sorted order is observable
+        var items = new[] { 3, 1, 4, 2 };
+
+        // act
+        var result = items.ToSortedList(x => x);
+
+        // assert — SortedList keys are always in ascending order
+        result.Count.Is(4);
+        result.Keys.IsEqual(new[] { 1, 2, 3, 4 });
+        result.Values.IsEqual(new[] { 1, 2, 3, 4 });
+    }
+
+    /// <summary>
+    /// ToSortedList with duplicate keys throws because the underlying ToDictionary
+    /// rejects duplicate keys with an ArgumentException.
+    /// </summary>
+    [Fact]
+    public void ToSortedList_DuplicateKeys_Throws()
+    {
+        var items = new[] { 1, 2, 1 };
+
+        Wrap.It(() => items.ToSortedList(x => x)).Throws<ArgumentException>();
     }
 }

--- a/base/Annium/tests/Annium.Tests/Linq/SortedListExtensionsTest.cs
+++ b/base/Annium/tests/Annium.Tests/Linq/SortedListExtensionsTest.cs
@@ -173,4 +173,17 @@ public class SortedListExtensionsTest
 
         static int Next(int x) => x + 1;
     }
+
+    /// <summary>
+    /// Verifies that GetChunks throws ArgumentException when start is greater than end.
+    /// </summary>
+    [Fact]
+    public void GetChunks_StartGreaterThanEnd_ThrowsArgumentException()
+    {
+        // arrange
+        var data = Enumerable.Range(1, 5).ToSortedList(x => x);
+
+        // act & assert
+        Wrap.It(() => data.GetChunks(5, 3, x => x + 1)).Throws<ArgumentException>();
+    }
 }

--- a/base/Annium/tests/Annium.Tests/Logging/VoidLoggerTests.cs
+++ b/base/Annium/tests/Annium.Tests/Logging/VoidLoggerTests.cs
@@ -33,8 +33,6 @@ public class VoidLoggerTests
         // Reaching here without an exception is the assertion.
         foreach (var level in new[] { LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error })
             logger.Log(this, "file.cs", "Member", 42, level, "msg", data);
-
-        true.IsTrue();
     }
 
     /// <summary>
@@ -48,7 +46,5 @@ public class VoidLoggerTests
 
         logger.Error(this, "file.cs", "Member", 42, new InvalidOperationException("boom"), data);
         logger.Error(this, "file.cs", "Member", 42, new Exception(), data);
-
-        true.IsTrue();
     }
 }

--- a/base/Annium/tests/Annium.Tests/Net/IPEndPointsTests.cs
+++ b/base/Annium/tests/Annium.Tests/Net/IPEndPointsTests.cs
@@ -80,4 +80,45 @@ public class IPEndPointsTests
         endpoint.Address.AddressFamily.Is(AddressFamily.InterNetwork);
         endpoint.Port.Is(1234);
     }
+
+    /// <summary>
+    /// Verifies that <c>ParseAsync</c> falls back to loopback (127.0.0.1) with the supplied default port
+    /// when the input cannot be parsed as a URI (e.g. contains a literal bracket that breaks URI syntax).
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task ParseAsync_UnparseableInput_FallsBackToLoopbackWithDefaultPort()
+    {
+        // "[::invalid" is not a valid URI host segment — Uri.TryCreate rejects it, so the method
+        // returns IPAddress.Loopback with the provided defaultPort.
+        var endpoint = await IPEndPoints.ParseAsync(
+            "[::invalid",
+            defaultPort: 7777,
+            ct: TestContext.Current.CancellationToken
+        );
+
+        endpoint.Address.Is(IPAddress.Loopback);
+        endpoint.Port.Is(7777);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ParseAsync</c> falls back to loopback (127.0.0.1) when the numeric host
+    /// is syntactically valid as a URI but cannot be parsed as an IP address (e.g. an out-of-range octet),
+    /// and uses the supplied default port.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task ParseAsync_InvalidIpOctet_FallsBackToLoopbackWithDefaultPort()
+    {
+        // "999.999.999.999" is accepted by Uri.TryCreate (no letters → DNS path skipped),
+        // but IPAddress.TryParse rejects it → final loopback fallback.
+        var endpoint = await IPEndPoints.ParseAsync(
+            "999.999.999.999:4321",
+            defaultPort: 0,
+            ct: TestContext.Current.CancellationToken
+        );
+
+        endpoint.Address.Is(IPAddress.Loopback);
+        endpoint.Port.Is(4321);
+    }
 }

--- a/base/Annium/tests/Annium.Tests/Security/SecureStringExtensionsTests.cs
+++ b/base/Annium/tests/Annium.Tests/Security/SecureStringExtensionsTests.cs
@@ -22,7 +22,7 @@ public class SecureStringExtensionsTests
         var source = "sample*$&тест123";
 
         // encode
-        var encoded = source.AsSecureString();
+        using var encoded = source.AsSecureString();
 
         // decode
         var decoded = Encoding.UTF8.GetString(encoded.AsBytes());
@@ -41,7 +41,7 @@ public class SecureStringExtensionsTests
         const string original = "hello";
 
         // act
-        var secure = original.AsSecureString();
+        using var secure = original.AsSecureString();
 
         // assert — unmarshal back to plain string for equality check
         var ptr = IntPtr.Zero;
@@ -68,7 +68,7 @@ public class SecureStringExtensionsTests
         var empty = Array.Empty<char>();
 
         // act
-        var secure = empty.AsSecureString();
+        using var secure = empty.AsSecureString();
 
         // assert
         secure.Length.Is(0);

--- a/base/Annium/tests/Annium.Tests/Threading/AsyncTimerTests.cs
+++ b/base/Annium/tests/Annium.Tests/Threading/AsyncTimerTests.cs
@@ -175,7 +175,6 @@ public class AsyncTimerTests : TestBase
         await timer.DisposeAsync();
 
         // Reaching here without hang or exception is the assertion.
-        true.IsTrue();
     }
 
     /// <summary>
@@ -254,7 +253,7 @@ public class AsyncTimerTests : TestBase
         using var handlerCts = new CancellationTokenSource();
         var handlerEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var handlerExited = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var timer = Timers.Async(
+        await using var timer = Timers.Async(
             async () =>
             {
                 handlerEntered.TrySetResult(true);

--- a/base/Annium/tests/Annium.Tests/Threading/Channels/ChannelReaderExtensionsTests.cs
+++ b/base/Annium/tests/Annium.Tests/Threading/Channels/ChannelReaderExtensionsTests.cs
@@ -100,7 +100,7 @@ public class ChannelReaderExtensionsTests : TestBase
         var channel = Channel.CreateUnbounded<int>();
 
         // act — bounded wait of 100 ms; if WhenEmptyAsync hangs the Wait.UntilAsync will time out
-        var whenEmpty = channel.Reader.WhenEmptyAsync(delay: 10, ct: TestContext.Current.CancellationToken);
+        var whenEmpty = channel.Reader.WhenEmptyAsync(delay: 10, ct: TestContext.Current.CancellationToken).AsTask();
         await Wait.UntilAsync(() => whenEmpty.IsCompleted, TestContext.Current.CancellationToken);
 
         // assert
@@ -121,7 +121,7 @@ public class ChannelReaderExtensionsTests : TestBase
         channel.Writer.TryWrite(3);
 
         // act — start the wait task before reading
-        var whenEmpty = channel.Reader.WhenEmptyAsync(delay: 10, ct: TestContext.Current.CancellationToken);
+        var whenEmpty = channel.Reader.WhenEmptyAsync(delay: 10, ct: TestContext.Current.CancellationToken).AsTask();
 
         // assert — task must NOT be complete while items remain
         whenEmpty.IsCompleted.IsFalse();
@@ -136,5 +136,94 @@ public class ChannelReaderExtensionsTests : TestBase
 
         // assert — task completes after all items are consumed
         whenEmpty.IsCompleted.IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies that when a writer's TryWrite throws an unexpected exception (not OperationCanceledException
+    /// or ChannelClosedException), the Pipe catches it via the general Exception branch, logs it at Error
+    /// level, and the pipe can then be disposed cleanly without throwing.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task Pipe_WriterThrowsUnexpectedException_LogsErrorAndDisposesCleanly()
+    {
+        this.Trace("start");
+
+        // arrange — source channel with one item ready to be read
+        var source = Channel.CreateUnbounded<int>();
+        source.Writer.TryWrite(42);
+
+        // A writer whose TryWrite always throws an unexpected exception to hit the general catch branch.
+        var throwingWriter = new ThrowingChannelWriter<int>(new InvalidOperationException("writer-boom"));
+
+        // act — create the pipe; the loop will read the item and call throwingWriter.Write which throws
+        var pipe = source.Reader.Pipe(throwingWriter, Logger);
+
+        // wait for the error-log entry to appear (the exception is bridged to the logger)
+        await Expect.ToAsync(
+            () =>
+                Logs.Any(m => m.Level == LogLevel.Error && m.Exception != null && m.Exception.Message == "writer-boom")
+                    .IsTrue(),
+            TestContext.Current.CancellationToken
+        );
+
+        // dispose must complete cleanly — no exception should propagate out
+        await pipe.DisposeAsync();
+
+        this.Trace("done");
+    }
+
+    /// <summary>
+    /// Verifies that WhenEmptyAsync completes without throwing when the cancellation token is cancelled
+    /// while the channel still has items (the OperationCanceledException is swallowed by the catch guard).
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task WhenEmptyAsync_CancelledWhilePolling_CompletesWithoutThrowing()
+    {
+        // arrange — channel with items so the polling loop keeps spinning
+        var channel = Channel.CreateUnbounded<int>();
+        channel.Writer.TryWrite(1);
+        channel.Writer.TryWrite(2);
+        channel.Writer.TryWrite(3);
+
+        using var cts = new CancellationTokenSource();
+
+        // act — start WhenEmptyAsync with our own CTS token (NOT the runner token)
+        var whenEmpty = channel.Reader.WhenEmptyAsync(delay: 10, ct: cts.Token).AsTask();
+
+        // cancel immediately; items are still in the channel so the loop is inside the delay
+        await cts.CancelAsync();
+
+        // assert — task must complete (OCE is swallowed) and must NOT propagate any exception
+        await whenEmpty;
+        whenEmpty.IsCompleted.IsTrue();
+        whenEmpty.IsFaulted.IsFalse();
+        whenEmpty.IsCanceled.IsFalse();
+    }
+
+    /// <summary>
+    /// ChannelWriter that throws a caller-supplied exception from TryWrite. Used to exercise
+    /// the general-exception branch in <see cref="ChannelReaderExtensions.Pipe{T}"/>.
+    /// </summary>
+    private sealed class ThrowingChannelWriter<T> : ChannelWriter<T>
+    {
+        private readonly Exception _ex;
+
+        public ThrowingChannelWriter(Exception ex)
+        {
+            _ex = ex;
+        }
+
+        /// <summary>
+        /// Always throws the configured exception to simulate an unexpected write failure.
+        /// </summary>
+        public override bool TryWrite(T item) => throw _ex;
+
+        /// <summary>
+        /// Returns a completed ValueTask so WaitToWriteAsync never blocks indefinitely.
+        /// </summary>
+        public override ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(true);
     }
 }

--- a/base/Annium/tests/Annium.Tests/Threading/DebounceTimerTests.cs
+++ b/base/Annium/tests/Annium.Tests/Threading/DebounceTimerTests.cs
@@ -153,8 +153,6 @@ public class DebounceTimerTests : TestBase
         // Must not throw — the IsDisposed guard + ObjectDisposedException catch in Request() absorbs the race.
         timer.Request();
         timer.Request();
-
-        true.IsTrue();
     }
 
     /// <summary>
@@ -179,8 +177,6 @@ public class DebounceTimerTests : TestBase
 
         await timer.DisposeAsync();
         await requester;
-
-        true.IsTrue();
     }
 
     /// <summary>

--- a/base/Annium/tests/Annium.Tests/Threading/SyncTimerTests.cs
+++ b/base/Annium/tests/Annium.Tests/Threading/SyncTimerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Annium.Logging;
@@ -160,6 +161,64 @@ public class SyncTimerTests : TestBase
         await EnsureValid(state);
 
         this.Trace("done");
+    }
+
+    /// <summary>
+    /// When the in-flight synchronous callback runs longer than <c>DisposeWaitBudget</c>, the
+    /// <see cref="System.Threading.Timer.Dispose(WaitHandle)"/> drain times out: dispose returns without
+    /// throwing and a warning is logged. The wait handle is intentionally leaked so the still-blocked
+    /// ThreadPool thread can eventually unblock and return without raising
+    /// <see cref="ObjectDisposedException"/>.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task Dispose_GateDrainTimesOut_LogsWarningAndDoesNotThrow()
+    {
+        // arrange — handler that blocks on its OWN gate past the 5s DisposeWaitBudget.
+        // The handler MUST NOT honour the xunit runner CT (otherwise early cancellation would let the
+        // handler return before the drain times out and the warn-log branch would never run).
+        // Pattern:
+        //   * handler waits on a ManualResetEventSlim using its own CTS — independent of the runner CT
+        //   * handler signals a TCS in its finally so the test can deterministically wait for cleanup
+        //   * test cancels the handler's gate AFTER Dispose returns (so the drain budget elapses first)
+        //     then awaits the TCS to ensure the handler has fully returned
+        using var handlerCts = new CancellationTokenSource();
+        var handlerEntered = new ManualResetEventSlim(false);
+        var handlerExited = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var blockGate = new ManualResetEventSlim(false);
+
+        var timer = Timers.Sync(
+            () =>
+            {
+                handlerEntered.Set();
+                try
+                {
+                    blockGate.Wait(handlerCts.Token);
+                }
+                catch (OperationCanceledException) { }
+                finally
+                {
+                    handlerExited.TrySetResult(true);
+                }
+            },
+            0,
+            10,
+            Logger
+        );
+
+        // wait until the handler is in-flight so Dispose has work to drain
+        handlerEntered.Wait(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        // act — dispose; the inner drain will time out after ~5s and the warn-log path runs
+        await timer.DisposeAsync();
+
+        // assert — drain-timeout warning was logged with the expected template
+        Logs.Any(l => l.Level == LogLevel.Warn && l.MessageTemplate.Contains("Timer drain exceeded")).IsTrue();
+
+        // cleanup — release the handler and wait for it to finish so the blocked ThreadPool thread
+        // is not left running after the test ends
+        await handlerCts.CancelAsync();
+        await handlerExited.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
     }
 
     private static Task EnsureValid(TimerTestHelpers.State state) => TimerTestHelpers.EnsureValidAsync(state);

--- a/base/Annium/tests/Annium.Tests/Threading/Tasks/AwaitableExtensionsTests.cs
+++ b/base/Annium/tests/Annium.Tests/Threading/Tasks/AwaitableExtensionsTests.cs
@@ -49,10 +49,20 @@ public class AwaitableExtensionsTests
     [Fact]
     public void Await_ValueTask_BlocksUntilCompletion()
     {
-        ValueTask.CompletedTask.Await();
+        var ct = TestContext.Current.CancellationToken;
+        var completed = false;
+        new ValueTask(
+            Task.Run(
+                async () =>
+                {
+                    await Task.Delay(50, ct);
+                    completed = true;
+                },
+                ct
+            )
+        ).Await();
 
-        // Reaching here without throwing is the assertion.
-        true.IsTrue();
+        completed.IsTrue();
     }
 
     /// <summary>

--- a/base/Annium/tests/Annium.Tests/Threading/Tasks/TaskSetTest.cs
+++ b/base/Annium/tests/Annium.Tests/Threading/Tasks/TaskSetTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Annium.Testing;
 using Annium.Threading.Tasks;
@@ -176,6 +177,61 @@ public class TaskSetTest
         v6.Is(6f);
         v7.Is(4u);
         v8.Is(8d);
+    }
+
+    /// <summary>
+    /// Verifies that WhenAll with one faulted task surfaces the original exception.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task WhenAll_2_OneFaults_SurfacesOriginalException()
+    {
+        // arrange
+        var t1 = Task.FromException<int>(new InvalidOperationException("boom"));
+        var t2 = T(true);
+
+        // act & assert
+        // VSTHRD003: awaiting TaskSet.WhenAll over caller-created faulted Tasks (Task.FromException) to exercise fault propagation — test-only.
+#pragma warning disable VSTHRD003
+        await Wrap.It(async () => await TaskSet.WhenAll(t1, t2)).ThrowsAsync<InvalidOperationException>();
+#pragma warning restore VSTHRD003
+    }
+
+    /// <summary>
+    /// Verifies that WhenAll with multiple faulted tasks surfaces an exception (first fault wins via await unwrapping).
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task WhenAll_2_MultipleFaults_SurfacesException()
+    {
+        // arrange
+        var t1 = Task.FromException<int>(new InvalidOperationException("first"));
+        var t2 = Task.FromException<bool>(new ArgumentException("second"));
+
+        // act & assert — awaiting Task.WhenAll unwraps AggregateException to the first inner exception
+        // VSTHRD003: awaiting TaskSet.WhenAll over caller-created faulted Tasks (Task.FromException) to exercise fault propagation — test-only.
+#pragma warning disable VSTHRD003
+        await Wrap.It(async () => await TaskSet.WhenAll(t1, t2)).ThrowsAsync<InvalidOperationException>();
+#pragma warning restore VSTHRD003
+    }
+
+    /// <summary>
+    /// Verifies that WhenAll with one faulted task among three surfaces the original exception.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task WhenAll_3_OneFaults_SurfacesOriginalException()
+    {
+        // arrange
+        var t1 = T(1);
+        var t2 = Task.FromException<bool>(new InvalidOperationException("boom"));
+        var t3 = T(2m);
+
+        // act & assert
+        // VSTHRD003: awaiting TaskSet.WhenAll over caller-created faulted Tasks (Task.FromException) to exercise fault propagation — test-only.
+#pragma warning disable VSTHRD003
+        await Wrap.It(async () => await TaskSet.WhenAll(t1, t2, t3)).ThrowsAsync<InvalidOperationException>();
+#pragma warning restore VSTHRD003
     }
 
     /// <summary>

--- a/base/Annium/tests/Annium.Tests/TrackingWeakReferenceTest.cs
+++ b/base/Annium/tests/Annium.Tests/TrackingWeakReferenceTest.cs
@@ -53,6 +53,44 @@ public class TrackingWeakReferenceTest
     }
 
     /// <summary>
+    /// Verifies that a subscriber that throws during OnCollected does not prevent a non-throwing
+    /// subscriber registered before it from firing. Exceptions thrown inside the ThreadPool workitem
+    /// are swallowed by the finalizer's catch block, so neither subscriber can crash the process.
+    /// The non-throwing subscriber is registered first so it fires before the throwing one.
+    /// </summary>
+    [Fact]
+    public void TrackingWeakReference_SubscriberException_NonThrowingSubscriberStillFires()
+    {
+        // arrange — signal to detect whether the non-throwing subscriber ran
+        using var fired = new ManualResetEventSlim(initialState: false);
+        object target;
+        ITrackingWeakReference<object> reference = default!;
+        Wrap(() =>
+        {
+            target = new object();
+            reference = TrackingWeakReference.Get(target);
+
+            // Register non-throwing subscriber FIRST so it runs before the throwing one.
+            // Multicast delegates fire in registration order; once the throwing one aborts,
+            // the outer try/catch in the workitem swallows it — so the signal is already set.
+            reference.OnCollected += () => fired.Set();
+            reference.OnCollected += () => throw new InvalidOperationException("subscriber-boom");
+        });
+
+        // act — drop the target and the reference so the finalizer runs
+        target = default!;
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+
+        reference = default!;
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+
+        // assert — non-throwing subscriber fired; process survived the throwing one
+        fired.Wait(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken).IsTrue();
+    }
+
+    /// <summary>
     /// Wraps an action to prevent inlining, ensuring proper garbage collection behavior.
     /// </summary>
     /// <param name="wrap">The action to wrap.</param>


### PR DESCRIPTION
- Annium.Testing: ThrowsAsync, Reports*Async, Expect.ToAsync now return ValueTask; Wait.While/UntilAsync and ChannelReaderExtensions.WhenEmptyAsync likewise
- collapse duplicate reflection generic-argument resolvers into shared helpers
- fix: WhenEmptyAsync swallows caller cancellation, matching its Wait siblings
- test: add faulted/error/disposal/edge-case coverage; drop tautological and order-fragile assertions; dispose IDisposable test locals