### PR TITLE
fix(core-mediator): merge crash, exception wrapping; debounce test

### DIFF
--- a/base/Annium/tests/Annium.Tests/Threading/DebounceTimerTests.cs
+++ b/base/Annium/tests/Annium.Tests/Threading/DebounceTimerTests.cs
@@ -43,7 +43,10 @@ public class DebounceTimerTests : TestBase
 
                 return ValueTask.CompletedTask;
             },
-            20,
+            // Debounce period (80ms) deliberately dominates the worst-case inter-chunk Task.Delay jitter
+            // (Task.Delay(1) can stretch to ~15ms under load); the three chunks therefore coalesce into a
+            // single fire per bulk regardless of scheduler jitter, keeping the fire count deterministic.
+            80,
             Logger
         );
 
@@ -59,8 +62,10 @@ public class DebounceTimerTests : TestBase
                 this.Trace("chunk delay");
                 await Task.Delay(1, TestContext.Current.CancellationToken);
             }
+            // Idle longer than the debounce period so the single coalesced fire lands within this bulk's
+            // window, before the next bulk's requests re-arm the timer.
             this.Trace("bulk delay");
-            await Task.Delay(50, TestContext.Current.CancellationToken);
+            await Task.Delay(200, TestContext.Current.CancellationToken);
         }
 
         // assert
@@ -90,7 +95,10 @@ public class DebounceTimerTests : TestBase
 
                 return ValueTask.CompletedTask;
             },
-            20,
+            // Debounce period (80ms) deliberately dominates the worst-case inter-chunk Task.Delay jitter
+            // (Task.Delay(1) can stretch to ~15ms under load); the three chunks therefore coalesce into a
+            // single fire per bulk regardless of scheduler jitter, keeping the fire count deterministic.
+            80,
             Logger
         );
 
@@ -106,8 +114,10 @@ public class DebounceTimerTests : TestBase
                 this.Trace("chunk delay");
                 await Task.Delay(1, TestContext.Current.CancellationToken);
             }
+            // Idle longer than the debounce period so the single coalesced fire lands within this bulk's
+            // window, before the next bulk's requests re-arm the timer.
             this.Trace("bulk delay");
-            await Task.Delay(50, TestContext.Current.CancellationToken);
+            await Task.Delay(200, TestContext.Current.CancellationToken);
         }
 
         // assert

--- a/base/Core/src/Annium.Core.Mediator/Internal/ChainElement.cs
+++ b/base/Core/src/Annium.Core.Mediator/Internal/ChainElement.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Reflection;
 
 namespace Annium.Core.Mediator.Internal;
 
 /// <summary>
 /// Represents a single element in the mediator execution chain
 /// </summary>
-internal record ChainElement
+internal class ChainElement
 {
     /// <summary>
     /// Type of the handler service for this chain element
@@ -18,22 +19,21 @@ internal record ChainElement
     public Delegate? Next { get; }
 
     /// <summary>
-    /// Initializes a new chain element with a handler (final element)
+    /// Handler's HandleAsync method, resolved lazily on first dispatch and memoized. The element's
+    /// runtime parameter types are stable across requests, so resolving once (by parameter types,
+    /// which also disambiguates handlers implementing multiple handler interfaces) avoids a
+    /// reflective GetMethod lookup on every request.
     /// </summary>
-    /// <param name="handler">Type of the handler service</param>
-    public ChainElement(Type handler)
-    {
-        Handler = handler;
-    }
+    public MethodInfo? Handle { get; set; }
 
     /// <summary>
-    /// Initializes a new chain element with a handler and next delegate
+    /// Initializes a new chain element with a handler and an optional next delegate
     /// </summary>
     /// <param name="handler">Type of the handler service</param>
-    /// <param name="next">Delegate to invoke the next element in the chain</param>
-    public ChainElement(Type handler, Delegate next)
-        : this(handler)
+    /// <param name="next">Delegate to invoke the next element in the chain; null for the final element</param>
+    public ChainElement(Type handler, Delegate? next = null)
     {
+        Handler = handler;
         Next = next;
     }
 

--- a/base/Core/src/Annium.Core.Mediator/Internal/ChainExecutor.cs
+++ b/base/Core/src/Annium.Core.Mediator/Internal/ChainExecutor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Annium.Core.DependencyInjection;
@@ -34,22 +35,44 @@ internal static class ChainExecutor
 
         var parameters = new List<object> { request, cancellationToken };
         if (hasNext)
-            parameters.Add(element.Next!.DynamicInvoke(provider, chain, index + 1)!);
+            parameters.Add(element.Next.NotNull().DynamicInvoke(provider, chain, index + 1).NotNull());
 
         var handler = element.Handler;
-        // hasNext=true means the current handler is a Pipe handler (3 params: request, ct, next);
-        // hasNext=false means it's the Final handler (2 params: request, ct).
-        var handleMethodName = hasNext ? Constants.PipeHandlerHandleAsyncName : Constants.FinalHandlerHandleAsyncName;
-        var handleMethod = handler.GetMethod(handleMethodName, parameters.Select(p => p.GetType()).ToArray())!;
-        var result = handleMethod.Invoke(provider.Resolve(handler), parameters.ToArray())!;
+        // Both IPipeRequestHandler and IFinalRequestHandler name the method "HandleAsync"; the pipe/final
+        // distinction is in the parameter count (3 with next when hasNext, else 2), captured in `parameters` above.
+        // Resolve the method once per chain element (its parameter types are stable) and memoize it.
+        var handleMethod = element.Handle;
+        if (handleMethod is null)
+        {
+            handleMethod = handler
+                .GetMethod(Constants.HandleAsyncName, parameters.Select(p => p.GetType()).ToArray())
+                .NotNull();
+            element.Handle = handleMethod;
+        }
+
+        // DoNotWrapExceptions: let a handler's own exceptions (e.g. OperationCanceledException) propagate
+        // directly instead of being wrapped in a TargetInvocationException by reflection.
+        var result = handleMethod
+            .Invoke(
+                provider.Resolve(handler),
+                BindingFlags.DoNotWrapExceptions,
+                binder: null,
+                parameters.ToArray(),
+                culture: null
+            )
+            .NotNull();
         await (Task)result;
 
         return result
             .GetType()
+            // VSTHRD103: nameof(Task<>.Result) is a reflection member-name reference, not a blocking .Result access
 #pragma warning disable VSTHRD103
-            .GetProperty(nameof(Task<>.Result))!
+            .GetProperty(nameof(Task<>.Result))
+            .NotNull()
 #pragma warning restore VSTHRD103
-            .GetGetMethod()!
-            .Invoke(result, Array.Empty<object>())!;
+            .GetGetMethod()
+            .NotNull()
+            .Invoke(result, Array.Empty<object>())
+            .NotNull();
     }
 }

--- a/base/Core/src/Annium.Core.Mediator/Internal/Constants.cs
+++ b/base/Core/src/Annium.Core.Mediator/Internal/Constants.cs
@@ -13,19 +13,14 @@ internal static class Constants
     public static readonly Type PipeHandlerType = typeof(IPipeRequestHandler<,,,>);
 
     /// <summary>
-    /// Method name for pipe handler HandleAsync method
-    /// </summary>
-    public static readonly string PipeHandlerHandleAsyncName = nameof(IPipeRequestHandler<,,,>.HandleAsync);
-
-    /// <summary>
     /// Type definition for final request handlers
     /// </summary>
     public static readonly Type FinalHandlerType = typeof(IFinalRequestHandler<,>);
 
     /// <summary>
-    /// Method name for final handler HandleAsync method
+    /// Method name of the handler method on both pipe and final request handlers (both name it "HandleAsync")
     /// </summary>
-    public static readonly string FinalHandlerHandleAsyncName = nameof(IFinalRequestHandler<,>.HandleAsync);
+    public static readonly string HandleAsyncName = nameof(IPipeRequestHandler<,,,>.HandleAsync);
 
     /// <summary>
     /// Type definition for request handler input interface

--- a/base/Core/src/Annium.Core.Mediator/Internal/Mediator.cs
+++ b/base/Core/src/Annium.Core.Mediator/Internal/Mediator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,8 +25,7 @@ internal class Mediator : IMediator
     /// <summary>
     /// Cache for storing built execution chains by input/output type pairs
     /// </summary>
-    private readonly IDictionary<ValueTuple<Type, Type>, IReadOnlyList<ChainElement>> _chainCache =
-        new Dictionary<ValueTuple<Type, Type>, IReadOnlyList<ChainElement>>();
+    private readonly ConcurrentDictionary<(Type, Type), IReadOnlyList<ChainElement>> _chainCache = new();
 
     /// <summary>
     /// Initializes a new instance of the Mediator class
@@ -47,12 +47,9 @@ internal class Mediator : IMediator
     /// <returns>Response of the specified type</returns>
     public async Task<TResponse> SendAsync<TResponse>(object request, CancellationToken ct = default)
     {
-        // get execution chain with last item, being final one
-        var chain = GetChain(request.GetType(), typeof(TResponse));
-
         // use scoped service provider
         await using var scope = _provider.CreateAsyncScope();
-        return (TResponse)await ChainExecutor.ExecuteAsync(scope.ServiceProvider, chain, request, ct);
+        return await DispatchAsync<TResponse>(scope.ServiceProvider, request, ct);
     }
 
     /// <summary>
@@ -63,17 +60,29 @@ internal class Mediator : IMediator
     /// <param name="request">Request object to process</param>
     /// <param name="ct">Cancellation token for the operation</param>
     /// <returns>Response of the specified type</returns>
-    public async Task<TResponse> SendAsync<TResponse>(
+    public Task<TResponse> SendAsync<TResponse>(
         IServiceProvider serviceProvider,
         object request,
         CancellationToken ct = default
+    ) => DispatchAsync<TResponse>(serviceProvider, request, ct);
+
+    /// <summary>
+    /// Builds (or reuses) the execution chain for the request and runs it on the given service provider
+    /// </summary>
+    /// <typeparam name="TResponse">Expected response type</typeparam>
+    /// <param name="provider">Service provider used to resolve handler instances</param>
+    /// <param name="request">Request object to process</param>
+    /// <param name="ct">Cancellation token for the operation</param>
+    /// <returns>Response of the specified type</returns>
+    private async Task<TResponse> DispatchAsync<TResponse>(
+        IServiceProvider provider,
+        object request,
+        CancellationToken ct
     )
     {
         // get execution chain with last item, being final one
         var chain = GetChain(request.GetType(), typeof(TResponse));
-
-        // use given service provider
-        return (TResponse)await ChainExecutor.ExecuteAsync(serviceProvider, chain, request, ct);
+        return (TResponse)await ChainExecutor.ExecuteAsync(provider, chain, request, ct);
     }
 
     /// <summary>
@@ -82,15 +91,6 @@ internal class Mediator : IMediator
     /// <param name="input">Input request type</param>
     /// <param name="output">Expected output response type</param>
     /// <returns>Execution chain for processing the request</returns>
-    private IReadOnlyList<ChainElement> GetChain(Type input, Type output)
-    {
-        lock (_chainCache)
-        {
-            var key = (input, output);
-            if (_chainCache.TryGetValue(key, out var chain))
-                return chain;
-
-            return _chainCache[key] = _chainBuilder.BuildExecutionChain(input, output);
-        }
-    }
+    private IReadOnlyList<ChainElement> GetChain(Type input, Type output) =>
+        _chainCache.GetOrAdd((input, output), _ => _chainBuilder.BuildExecutionChain(input, output));
 }

--- a/base/Core/src/Annium.Core.Mediator/Internal/NextBuilder.cs
+++ b/base/Core/src/Annium.Core.Mediator/Internal/NextBuilder.cs
@@ -16,25 +16,28 @@ internal class NextBuilder
     /// <summary>
     /// Cached reference to ChainExecutor.ExecuteAsync method
     /// </summary>
-    private readonly MethodInfo _executeAsync = typeof(ChainExecutor).GetMethod(
-        nameof(ChainExecutor.ExecuteAsync),
-        BindingFlags.Public | BindingFlags.Static
-    )!;
+    private static readonly MethodInfo _executeAsync = typeof(ChainExecutor)
+        .GetMethod(nameof(ChainExecutor.ExecuteAsync), BindingFlags.Public | BindingFlags.Static)
+        .NotNull();
 
     /// <summary>
     /// Cached reference to Task.GetAwaiter method
     /// </summary>
-    private readonly MethodInfo _getAwaiter = typeof(Task<object>).GetMethod(nameof(Task<>.GetAwaiter))!;
+    private static readonly MethodInfo _getAwaiter = typeof(Task<object>)
+        .GetMethod(nameof(Task<>.GetAwaiter))
+        .NotNull();
 
     /// <summary>
     /// Cached reference to TaskAwaiter.GetResult method
     /// </summary>
-    private readonly MethodInfo _getResult = typeof(TaskAwaiter<object>).GetMethod(nameof(TaskAwaiter<>.GetResult))!;
+    private static readonly MethodInfo _getResult = typeof(TaskAwaiter<object>)
+        .GetMethod(nameof(TaskAwaiter<>.GetResult))
+        .NotNull();
 
     /// <summary>
     /// Cached reference to Task.FromResult method
     /// </summary>
-    private readonly MethodInfo _fromResult = typeof(Task).GetMethod(nameof(Task.FromResult))!;
+    private static readonly MethodInfo _fromResult = typeof(Task).GetMethod(nameof(Task.FromResult)).NotNull();
 
     /// <summary>
     /// Builds a delegate function for invoking the next handler in the chain

--- a/base/Core/src/Annium.Core.Mediator/MediatorConfiguration.cs
+++ b/base/Core/src/Annium.Core.Mediator/MediatorConfiguration.cs
@@ -18,31 +18,52 @@ public class MediatorConfiguration
     /// <returns>Merged configuration containing all handlers and matches</returns>
     internal static MediatorConfiguration Merge(params MediatorConfiguration[] configurations)
     {
-        return new(
-            configurations.SelectMany(c => c.Handlers).ToList(),
-            configurations.SelectMany(c => c.Matches).ToList()
-        );
+        var handlers = configurations.SelectMany(c => c.Handlers).ToList();
+
+        // AddMatch dedups/ambiguity-checks matches within a single config; the same must hold across
+        // merged configs, otherwise duplicate (RequestedType, ExpectedType) entries make ChainBuilder's
+        // SingleOrDefault throw a cryptic "Sequence contains more than one element".
+        var matches = new List<Match>();
+        foreach (var match in configurations.SelectMany(c => c.Matches))
+        {
+            var existing = matches.FirstOrDefault(x =>
+                x.RequestedType == match.RequestedType && x.ExpectedType == match.ExpectedType
+            );
+            if (existing is null)
+            {
+                matches.Add(match);
+                continue;
+            }
+
+            if (existing.ResolvedType != match.ResolvedType)
+                throw new InvalidOperationException(
+                    $"Match {match} conflicts with {existing}: the same requested/expected type pair resolves to different types across configurations"
+                );
+            // identical match registered in another configuration — skip the duplicate
+        }
+
+        return new(handlers, matches);
     }
 
     /// <summary>
     /// Collection of registered request handlers
     /// </summary>
-    internal IEnumerable<Handler> Handlers => _handlers;
+    internal IReadOnlyList<Handler> Handlers => _handlers;
 
     /// <summary>
     /// Collection of registered type matches
     /// </summary>
-    internal IEnumerable<Match> Matches => _matches;
+    internal IReadOnlyList<Match> Matches => _matches;
 
     /// <summary>
     /// Internal storage for request handlers
     /// </summary>
-    private readonly IList<Handler> _handlers;
+    private readonly List<Handler> _handlers;
 
     /// <summary>
     /// Internal storage for type matches
     /// </summary>
-    private readonly IList<Match> _matches;
+    private readonly List<Match> _matches;
 
     /// <summary>
     /// Initializes a new empty mediator configuration
@@ -55,7 +76,7 @@ public class MediatorConfiguration
     /// </summary>
     /// <param name="handlers">List of request handlers</param>
     /// <param name="matches">List of type matches</param>
-    private MediatorConfiguration(IList<Handler> handlers, IList<Match> matches)
+    private MediatorConfiguration(List<Handler> handlers, List<Match> matches)
     {
         _handlers = handlers;
         _matches = matches;
@@ -104,20 +125,9 @@ public class MediatorConfiguration
     /// <returns>This configuration instance for method chaining</returns>
     public MediatorConfiguration AddMatch(Type requestType, Type expectedType, Type resolvedType)
     {
-        if (requestType.IsGenericTypeParameter || requestType.ContainsGenericParameters)
-            throw new InvalidOperationException(
-                $"Requested type {requestType.FriendlyName()} can't be registered in request/response match, because it is generic"
-            );
-
-        if (expectedType.IsGenericTypeParameter || expectedType.ContainsGenericParameters)
-            throw new InvalidOperationException(
-                $"Expected type {expectedType.FriendlyName()} can't be registered in request/response match, because it is generic"
-            );
-
-        if (resolvedType.IsGenericTypeParameter || resolvedType.ContainsGenericParameters)
-            throw new InvalidOperationException(
-                $"Resolved type {expectedType.FriendlyName()} can't be registered in request/response match, because it is generic"
-            );
+        ThrowIfGeneric(requestType, "Requested");
+        ThrowIfGeneric(expectedType, "Expected");
+        ThrowIfGeneric(resolvedType, "Resolved");
 
         if (!expectedType.IsAssignableFrom(resolvedType))
             throw new InvalidOperationException(
@@ -143,5 +153,18 @@ public class MediatorConfiguration
         }
 
         return this;
+    }
+
+    /// <summary>
+    /// Throws if the given type is an open generic (a generic type parameter or contains unbound generic parameters)
+    /// </summary>
+    /// <param name="type">Type to validate</param>
+    /// <param name="label">Role label used in the error message (e.g. "Requested", "Expected", "Resolved")</param>
+    private static void ThrowIfGeneric(Type type, string label)
+    {
+        if (type.IsGenericTypeParameter || type.ContainsGenericParameters)
+            throw new InvalidOperationException(
+                $"{label} type {type.FriendlyName()} can't be registered in request/response match, because it is generic"
+            );
     }
 }

--- a/base/Core/src/Annium.Core.Mediator/ServiceContainerExtensions.cs
+++ b/base/Core/src/Annium.Core.Mediator/ServiceContainerExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Annium.Core.DependencyInjection;
 using Annium.Core.Mediator.Internal;
 using Annium.Core.Runtime;
@@ -55,7 +56,7 @@ public static class ServiceContainerExtensions
     {
         container.Add<ChainBuilder>().AsSelf().Singleton();
         container.Add<NextBuilder>().AsSelf().Singleton();
-        container.Add<IMediator, Internal.Mediator>().AsSelf().Singleton();
+        container.Add<IMediator, Internal.Mediator>().Singleton();
 
         return container;
     }
@@ -72,8 +73,8 @@ public static class ServiceContainerExtensions
     )
     {
         container.Add(cfg).AsSelf().Singleton();
-        foreach (var handler in cfg.Handlers)
-            container.Add(handler.Implementation).AsSelf().Scoped();
+        foreach (var implementation in cfg.Handlers.Select(h => h.Implementation).Distinct())
+            container.Add(implementation).AsSelf().Scoped();
 
         return container;
     }

--- a/base/Core/tests/Annium.Core.Mediator.Tests/MediatorTest.cs
+++ b/base/Core/tests/Annium.Core.Mediator.Tests/MediatorTest.cs
@@ -2,12 +2,14 @@ using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Annium.Core.DependencyInjection;
 using Annium.Data.Operations;
 using Annium.Data.Operations.Serialization.Json;
 using Annium.Logging;
 using Annium.Logging.InMemory;
 using Annium.Logging.Shared;
 using Annium.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Annium.Core.Mediator.Tests;
@@ -19,6 +21,9 @@ namespace Annium.Core.Mediator.Tests;
 /// </summary>
 public class MediatorTest
 {
+    /// <summary>JSON serializer options configured for operations serialization, shared across the test handlers and wrappers.</summary>
+    private static readonly JsonSerializerOptions _options = new JsonSerializerOptions().ConfigureForOperations();
+
     /// <summary>The test output helper used for logging within this test class.</summary>
     private readonly ITestOutputHelper _outputHelper;
 
@@ -45,7 +50,7 @@ public class MediatorTest
 
         var response = await mediator.SendAsync<One>(request, TestContext.Current.CancellationToken);
 
-        response.GetHashCode().Is(new One { First = request.Value.Length, Value = request.Value }.GetHashCode());
+        AssertClosedHandlerResult(response, request);
     }
 
     /// <summary>
@@ -62,7 +67,7 @@ public class MediatorTest
 
         var response = await mediator.SendAsync<Base>(request, TestContext.Current.CancellationToken);
 
-        response.GetHashCode().Is(new Base { Value = "one_two_three" }.GetHashCode());
+        response.Value.Is("one_two_three");
     }
 
     /// <summary>
@@ -72,11 +77,7 @@ public class MediatorTest
     [Fact]
     public async Task ChainOfHandlers_WithExpectedParameters_Works()
     {
-        await using var fx = await BuildAsync(cfg =>
-            cfg.AddHandler(typeof(ConversionHandler<,>))
-                .AddHandler(typeof(ValidationHandler<,>))
-                .AddHandler(typeof(OpenFinalHandler<,>))
-        );
+        await using var fx = await BuildAsync(cfg => AddPipeChain(cfg));
 
         var mediator = fx.Get<IMediator>();
         var request = new Two { Second = 2, Value = "one two three" };
@@ -86,8 +87,7 @@ public class MediatorTest
             await mediator.SendAsync<Response<IBooleanResult<Base>>>(payload, TestContext.Current.CancellationToken)
         ).Value;
 
-        response.IsSuccess.IsTrue();
-        response.Data.GetHashCode().Is(new Base { Value = "one_two_three" }.GetHashCode());
+        AssertPipeSuccess(response);
     }
 
     /// <summary>
@@ -98,10 +98,7 @@ public class MediatorTest
     public async Task ChainOfHandlers_WithRegisteredResponse_Works()
     {
         await using var fx = await BuildAsync(cfg =>
-            cfg.AddHandler(typeof(ConversionHandler<,>))
-                .AddHandler(typeof(ValidationHandler<,>))
-                .AddHandler(typeof(OpenFinalHandler<,>))
-                .AddMatch(typeof(Request<Two>), typeof(IResponse), typeof(Response<IBooleanResult<Base>>))
+            AddPipeChain(cfg).AddMatch(typeof(Request<Two>), typeof(IResponse), typeof(Response<IBooleanResult<Base>>))
         );
 
         var mediator = fx.Get<IMediator>();
@@ -112,8 +109,568 @@ public class MediatorTest
             .As<Response<IBooleanResult<Base>>>()
             .Value;
 
+        AssertPipeSuccess(response);
+    }
+
+    // -------------------------------------------------------------------------
+    // GROUP A — MediatorConfiguration validation (throws synchronously during configure(cfg))
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Registers the standard three-handler pipe chain (ConversionHandler → ValidationHandler → OpenFinalHandler)
+    /// onto <paramref name="cfg"/> and returns it for further chaining.
+    /// </summary>
+    /// <param name="cfg">The mediator configuration to add the handlers to.</param>
+    /// <returns>The same configuration instance for method chaining.</returns>
+    private static MediatorConfiguration AddPipeChain(MediatorConfiguration cfg) =>
+        cfg.AddHandler(typeof(ConversionHandler<,>))
+            .AddHandler(typeof(ValidationHandler<,>))
+            .AddHandler(typeof(OpenFinalHandler<,>));
+
+    /// <summary>
+    /// Asserts that <paramref name="response"/> represents a successful pipe result with the
+    /// canonicalized "one_two_three" value.
+    /// </summary>
+    /// <param name="response">The boolean result wrapping the <see cref="Base"/> response.</param>
+    private static void AssertPipeSuccess(IBooleanResult<Base> response)
+    {
         response.IsSuccess.IsTrue();
-        response.Data.GetHashCode().Is(new Base { Value = "one_two_three" }.GetHashCode());
+        response.Data.Value.Is("one_two_three");
+    }
+
+    /// <summary>
+    /// Asserts that a <see cref="ClosedFinalHandler"/> response correctly reflects the originating
+    /// <paramref name="request"/>: the value is preserved and <see cref="One.First"/> equals the
+    /// value's character count.
+    /// </summary>
+    /// <param name="response">The mapped <see cref="One"/> response.</param>
+    /// <param name="request">The originating <see cref="Base"/> request.</param>
+    private static void AssertClosedHandlerResult(One response, Base request)
+    {
+        response.Value.Is(request.Value);
+        response.First.Is((long)request.Value.NotNull().Length);
+    }
+
+    /// <summary>
+    /// Asserts that applying <paramref name="configure"/> to a fresh configuration throws
+    /// <see cref="InvalidOperationException"/>. The configure action runs synchronously inside
+    /// <c>AddMediatorConfiguration</c>, so the guard exception propagates immediately.
+    /// </summary>
+    /// <param name="configure">The configuration action expected to throw.</param>
+    private static void ThrowsOnConfigure(Action<MediatorConfiguration> configure) =>
+        Wrap.It(() => new ServiceContainer().AddMediatorConfiguration(configure)).Throws<InvalidOperationException>();
+
+    /// <summary>
+    /// Tests that registering a non-handler type as a mediator handler throws.
+    /// </summary>
+    [Fact]
+    public void AddHandler_NonHandlerType_Throws() => ThrowsOnConfigure(cfg => cfg.AddHandler(typeof(object)));
+
+    /// <summary>
+    /// Tests that adding a match with a generic requested type throws.
+    /// </summary>
+    [Fact]
+    public void AddMatch_GenericRequestedType_Throws() =>
+        ThrowsOnConfigure(cfg => cfg.AddMatch(typeof(System.Collections.Generic.List<>), typeof(Base), typeof(One)));
+
+    /// <summary>
+    /// Tests that adding a match with a generic expected type throws.
+    /// </summary>
+    [Fact]
+    public void AddMatch_GenericExpectedType_Throws() =>
+        ThrowsOnConfigure(cfg => cfg.AddMatch(typeof(Two), typeof(System.Collections.Generic.List<>), typeof(One)));
+
+    /// <summary>
+    /// Tests that adding a match with a generic resolved type throws.
+    /// </summary>
+    [Fact]
+    public void AddMatch_GenericResolvedType_Throws() =>
+        ThrowsOnConfigure(cfg => cfg.AddMatch(typeof(Two), typeof(Base), typeof(System.Collections.Generic.List<>)));
+
+    /// <summary>
+    /// Tests that AddMatch throws when the resolved type is not assignable to the expected type.
+    /// Two/IResponse/One are all non-generic (generic guards pass); One does not implement IResponse,
+    /// so the assignability guard fires and throws InvalidOperationException.
+    /// </summary>
+    [Fact]
+    public void AddMatch_ResolvedTypeNotAssignableToExpected_Throws() =>
+        ThrowsOnConfigure(cfg => cfg.AddMatch(typeof(Two), typeof(IResponse), typeof(One)));
+
+    /// <summary>
+    /// Tests that registering two matches with the same requested/expected pair but different resolved types throws.
+    /// </summary>
+    [Fact]
+    public void AddMatch_AmbiguousDuplicate_Throws() =>
+        ThrowsOnConfigure(cfg =>
+        {
+            cfg.AddMatch(typeof(Two), typeof(Base), typeof(One));
+            cfg.AddMatch(typeof(Two), typeof(Base), typeof(Two));
+        });
+
+    /// <summary>
+    /// Tests that passing a bare type parameter (e.g. the T from <c>List&lt;&gt;</c>) as the requested
+    /// type to <see cref="MediatorConfiguration.AddMatch"/> throws because
+    /// <c>ThrowIfGeneric</c> detects <c>IsGenericTypeParameter == true</c>.
+    /// </summary>
+    [Fact]
+    public void AddMatch_BareTypeParameterRequested_Throws() =>
+        ThrowsOnConfigure(cfg =>
+            cfg.AddMatch(typeof(System.Collections.Generic.List<>).GetGenericArguments()[0], typeof(Base), typeof(One))
+        );
+
+    /// <summary>
+    /// Tests that registering the same match twice within one config is silently deduplicated: it neither
+    /// throws at configure time nor produces a duplicate that would make ChainBuilder's SingleOrDefault throw at dispatch.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task AddMatch_IdenticalDuplicate_Accepted()
+    {
+        // The same (Request<Two>, IResponse, Response<...>) match is registered twice in ONE config.
+        // If AddMatch did not dedupe, two identical matches would survive and ResolveOutput's
+        // SingleOrDefault would throw "Sequence contains more than one element" at dispatch.
+        await using var fx = await BuildAsync(cfg =>
+            AddPipeChain(cfg)
+                .AddMatch(typeof(Request<Two>), typeof(IResponse), typeof(Response<IBooleanResult<Base>>))
+                .AddMatch(typeof(Request<Two>), typeof(IResponse), typeof(Response<IBooleanResult<Base>>))
+        );
+
+        var mediator = fx.Get<IMediator>();
+        var payload = new Request<Two>(new Two { Second = 2, Value = "one two three" });
+
+        var response = (await mediator.SendAsync<IResponse>(payload, TestContext.Current.CancellationToken))
+            .As<Response<IBooleanResult<Base>>>()
+            .Value;
+
+        AssertPipeSuccess(response);
+    }
+
+    // -------------------------------------------------------------------------
+    // GROUP B — Merge across two AddMediatorConfiguration calls (conflict detected at provider build)
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Tests that two configurations with conflicting matches for the same requested/expected pair throw during provider build.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task TwoConfigurations_ConflictingMatch_Throws()
+    {
+        await using var fx = new Fixture(_outputHelper);
+        // Override the standard Configure path — register two conflicting configs manually.
+        fx.Register(container =>
+        {
+            Fixture.RegisterValidators(container);
+            container.AddMediatorConfiguration(cfg =>
+                cfg.AddHandler(typeof(ClosedFinalHandler)).AddMatch(typeof(Two), typeof(Base), typeof(One))
+            );
+            container.AddMediatorConfiguration(cfg => cfg.AddMatch(typeof(Two), typeof(Base), typeof(Two)));
+            container.AddMediator();
+        });
+        fx.Setup(sp =>
+        {
+            sp.UseLogging(route =>
+                route.For(m => m.SubjectType.StartsWith("ClosedFinalHandler")).UseInMemory<DefaultLogContext>()
+            );
+        });
+        await fx.InitializeAsync();
+
+        // ChainBuilder.Merge runs in the ChainBuilder constructor, which the singleton IMediator
+        // instantiates on first resolve — that is where the cross-config match conflict surfaces.
+        Wrap.It(() => fx.Get<IMediator>()).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// Tests that two configurations registering the same match are silently deduplicated and the pipeline works.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task TwoConfigurations_IdenticalMatch_Works()
+    {
+        await using var fx = new Fixture(_outputHelper);
+        var matchArgs = (typeof(Request<Two>), typeof(IResponse), typeof(Response<IBooleanResult<Base>>));
+        fx.Register(container =>
+        {
+            Fixture.RegisterValidators(container);
+            container.AddMediatorConfiguration(cfg =>
+                AddPipeChain(cfg).AddMatch(matchArgs.Item1, matchArgs.Item2, matchArgs.Item3)
+            );
+            // Second config registers the identical match — should be deduplicated without error.
+            container.AddMediatorConfiguration(cfg => cfg.AddMatch(matchArgs.Item1, matchArgs.Item2, matchArgs.Item3));
+            container.AddMediator();
+        });
+        fx.Setup(sp =>
+        {
+            sp.UseLogging(route =>
+                route
+                    .For(m =>
+                        m.SubjectType.StartsWith("ConversionHandler")
+                        || m.SubjectType.StartsWith("ValidationHandler")
+                        || m.SubjectType.StartsWith("OpenFinalHandler")
+                    )
+                    .UseInMemory<DefaultLogContext>()
+            );
+        });
+        await fx.InitializeAsync();
+
+        var mediator = fx.Get<IMediator>();
+        var request = new Two { Second = 2, Value = "one two three" };
+        var payload = new Request<Two>(request);
+
+        var response = (await mediator.SendAsync<IResponse>(payload, TestContext.Current.CancellationToken))
+            .As<Response<IBooleanResult<Base>>>()
+            .Value;
+
+        AssertPipeSuccess(response);
+    }
+
+    /// <summary>
+    /// Tests that Merge concatenates handlers contributed by SEPARATE configurations into one chain:
+    /// config 1 registers the pipe handlers, config 2 registers the final handler, and dispatch builds
+    /// a complete chain across both configs and succeeds.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task TwoConfigurations_HandlersSplitAcrossConfigs_DispatchSucceeds()
+    {
+        await using var fx = new Fixture(_outputHelper);
+        fx.Register(container =>
+        {
+            Fixture.RegisterValidators(container);
+            // config 1 contributes only the pipe handlers
+            container.AddMediatorConfiguration(cfg =>
+                cfg.AddHandler(typeof(ConversionHandler<,>)).AddHandler(typeof(ValidationHandler<,>))
+            );
+            // config 2 contributes only the final handler
+            container.AddMediatorConfiguration(cfg => cfg.AddHandler(typeof(OpenFinalHandler<,>)));
+            container.AddMediator();
+        });
+        fx.Setup(sp =>
+        {
+            sp.UseLogging(route =>
+                route
+                    .For(m =>
+                        m.SubjectType.StartsWith("ConversionHandler")
+                        || m.SubjectType.StartsWith("ValidationHandler")
+                        || m.SubjectType.StartsWith("OpenFinalHandler")
+                    )
+                    .UseInMemory<DefaultLogContext>()
+            );
+        });
+        await fx.InitializeAsync();
+
+        var mediator = fx.Get<IMediator>();
+        var payload = new Request<Two>(new Two { Second = 2, Value = "one two three" });
+
+        var response = (
+            await mediator.SendAsync<Response<IBooleanResult<Base>>>(payload, TestContext.Current.CancellationToken)
+        ).Value;
+
+        AssertPipeSuccess(response);
+    }
+
+    // -------------------------------------------------------------------------
+    // GROUP C — Pipeline behavior
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Tests that a cancelled token propagates OperationCanceledException through the pipe-handler branch
+    /// (hasNext=true in ChainExecutor), exercising DoNotWrapExceptions on the pipe handler invocation.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task SendAsync_CancelledToken_PipeHandlerThrows_PropagatesOperationCanceledException()
+    {
+        // Register pipe handler FIRST so the chain is [pipe, final] for Base → One.
+        await using var fx = await BuildAsync(cfg =>
+            cfg.AddHandler(typeof(CancelObservingPipeHandler)).AddHandler(typeof(ClosedFinalHandler))
+        );
+
+        var mediator = fx.Get<IMediator>();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Wrap.It(async () => await mediator.SendAsync<One>(new Base { Value = "base" }, cts.Token))
+            .ThrowsAsync<OperationCanceledException>();
+    }
+
+    /// <summary>
+    /// Tests that the default SendAsync overload opens a fresh AsyncScope per call so a Scoped
+    /// handler resolves a distinct instance for each invocation.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task SendAsync_DefaultOverload_CreatesFreshScopePerCall()
+    {
+        await using var fx = new Fixture(_outputHelper);
+        fx.Register(container =>
+        {
+            Fixture.RegisterValidators(container);
+            container.Add(new InstanceCollector()).AsSelf().Singleton();
+            container.AddMediatorConfiguration(cfg => cfg.AddHandler(typeof(ScopeProbeHandler)));
+            container.AddMediator();
+        });
+        fx.Setup(sp =>
+            sp.UseLogging(route =>
+                route.For(m => m.SubjectType.StartsWith("ScopeProbeHandler")).UseInMemory<DefaultLogContext>()
+            )
+        );
+        await fx.InitializeAsync();
+
+        var mediator = fx.Get<IMediator>();
+        var ct = TestContext.Current.CancellationToken;
+
+        await mediator.SendAsync<One>(new Base { Value = "base" }, ct);
+        await mediator.SendAsync<One>(new Base { Value = "base" }, ct);
+
+        var collector = fx.Get<InstanceCollector>();
+        // Two calls must have produced exactly two handler invocations.
+        collector.Ids.Has(2);
+        // Each call opened a fresh scope, so each call created a fresh ScopeProbeHandler instance.
+        (collector.Ids[0] != collector.Ids[1]).IsTrue();
+    }
+
+    /// <summary>
+    /// Tests that dispatching with an already-cancelled token propagates OperationCanceledException.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task SendAsync_CancelledToken_ThrowsOperationCanceledException()
+    {
+        await using var fx = await BuildAsync(cfg => cfg.AddHandler(typeof(CancelObservingFinalHandler)));
+
+        var mediator = fx.Get<IMediator>();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Wrap.It(async () => await mediator.SendAsync<One>(new Base { Value = "base" }, cts.Token))
+            .ThrowsAsync<OperationCanceledException>();
+    }
+
+    /// <summary>
+    /// Tests that sending a request for which no handler is registered throws.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task SendAsync_NoHandlerRegistered_Throws()
+    {
+        // Register a handler that covers Base->One but try to send One->Two (unresolvable).
+        await using var fx = await BuildAsync(cfg => cfg.AddHandler(typeof(ClosedFinalHandler)));
+
+        var mediator = fx.Get<IMediator>();
+
+        await Wrap.It(async () =>
+                await mediator.SendAsync<Two>(new One { Value = "x", First = 1 }, TestContext.Current.CancellationToken)
+            )
+            .ThrowsAsync<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// Tests that two AddMediatorConfiguration calls each registering the same handler type still dispatch correctly.
+    /// MediatorConfiguration.Merge concatenates handlers without deduplication, so two identical Handler entries
+    /// exist after the merge; ChainBuilder uses the first match and the duplicate is harmlessly ignored.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task TwoConfigurations_DuplicateHandler_DispatchSucceeds()
+    {
+        await using var fx = new Fixture(_outputHelper);
+        fx.Register(container =>
+        {
+            Fixture.RegisterValidators(container);
+            container.AddMediatorConfiguration(cfg => cfg.AddHandler(typeof(ClosedFinalHandler)));
+            container.AddMediatorConfiguration(cfg => cfg.AddHandler(typeof(ClosedFinalHandler)));
+            container.AddMediator();
+        });
+        fx.Setup(sp =>
+        {
+            sp.UseLogging(route =>
+                route.For(m => m.SubjectType.StartsWith("ClosedFinalHandler")).UseInMemory<DefaultLogContext>()
+            );
+        });
+        await fx.InitializeAsync();
+
+        var mediator = fx.Get<IMediator>();
+        var request = new Base { Value = "base" };
+
+        var response = await mediator.SendAsync<One>(request, TestContext.Current.CancellationToken);
+
+        AssertClosedHandlerResult(response, request);
+    }
+
+    /// <summary>
+    /// Tests that dispatching a request that matches a pipe handler, but whose transformed inner types have no
+    /// registered final handler, throws <see cref="InvalidOperationException"/> at chain-build time.
+    /// ConversionHandler&lt;Two,Base&gt; matches (Request&lt;Two&gt;, Response&lt;Base&gt;) and advances the chain
+    /// to (Two, Base); since no handler covers (Two, Base), ChainBuilder throws before any handler body runs.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task SendAsync_PipeHandlerWithNoFinalForTransformedType_Throws()
+    {
+        await using var fx = await BuildAsync(cfg => cfg.AddHandler(typeof(ConversionHandler<,>)));
+
+        var mediator = fx.Get<IMediator>();
+        var payload = new Request<Two>(new Two { Second = 2, Value = "one two three" });
+
+        await Wrap.It(async () =>
+                await mediator.SendAsync<Response<Base>>(payload, TestContext.Current.CancellationToken)
+            )
+            .ThrowsAsync<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// Tests that a chain of handlers returns a failure result when validation fails.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task ChainOfHandlers_ValidationFails_ReturnsFailure()
+    {
+        await using var fx = await BuildAsync(cfg => AddPipeChain(cfg));
+
+        var mediator = fx.Get<IMediator>();
+        // Second = 1 (odd) — Func<Two,bool> evaluates to false, ValidationHandler returns failure.
+        var request = new Two { Second = 1, Value = "one two three" };
+        var payload = new Request<Two>(request);
+
+        var response = (
+            await mediator.SendAsync<Response<IBooleanResult<Base>>>(payload, TestContext.Current.CancellationToken)
+        ).Value;
+
+        response.IsSuccess.IsFalse();
+        response.HasErrors.IsTrue();
+    }
+
+    /// <summary>
+    /// Tests that SendAsync with an explicit IServiceProvider overload produces the same result.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task SendAsync_WithExplicitServiceProvider_Works()
+    {
+        await using var fx = await BuildAsync(cfg => cfg.AddHandler(typeof(ClosedFinalHandler)));
+
+        var mediator = fx.Get<IMediator>();
+        var request = new Base { Value = "base" };
+
+        // bring-your-own-scope overload: the caller owns the scope and the mediator dispatches against
+        // the supplied provider directly (no nested scope). Exercise it with a real explicit scope.
+        await using var scope = fx.Provider.CreateAsyncScope();
+        var response = await mediator.SendAsync<One>(
+            scope.ServiceProvider,
+            request,
+            TestContext.Current.CancellationToken
+        );
+
+        AssertClosedHandlerResult(response, request);
+    }
+
+    /// <summary>
+    /// Tests that calling SendAsync twice reuses the cached chain and both calls succeed.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task SendAsync_SameTypeTwice_BothSucceed()
+    {
+        await using var fx = await BuildAsync(cfg => cfg.AddHandler(typeof(ClosedFinalHandler)));
+
+        var mediator = fx.Get<IMediator>();
+        var request = new Base { Value = "base" };
+        var ct = TestContext.Current.CancellationToken;
+
+        var first = await mediator.SendAsync<One>(request, ct);
+        var second = await mediator.SendAsync<One>(request, ct);
+
+        AssertClosedHandlerResult(first, request);
+        AssertClosedHandlerResult(second, request);
+    }
+
+    /// <summary>
+    /// Tests that calling <c>AddMediator</c> with no <c>AddMediatorConfiguration</c> at all (so ChainBuilder
+    /// merges an empty configuration set) throws <see cref="InvalidOperationException"/> at first dispatch
+    /// rather than at container-build time.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task SendAsync_AddMediatorWithoutConfiguration_Throws()
+    {
+        await using var fx = new Fixture(_outputHelper);
+        fx.Register(container =>
+        {
+            Fixture.RegisterValidators(container);
+            // intentionally no AddMediatorConfiguration → ChainBuilder receives an empty config set
+            container.AddMediator();
+        });
+        await fx.InitializeAsync();
+
+        var mediator = fx.Get<IMediator>();
+
+        await Wrap.It(async () =>
+                await mediator.SendAsync<One>(new Base { Value = "base" }, TestContext.Current.CancellationToken)
+            )
+            .ThrowsAsync<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// Tests that a non-cancellation exception thrown by a handler propagates as its ORIGINAL type
+    /// (e.g. <see cref="FormatException"/>), not wrapped in a <c>TargetInvocationException</c> — confirming
+    /// ChainExecutor invokes handlers with <c>BindingFlags.DoNotWrapExceptions</c> for arbitrary exception types
+    /// (the cancellation tests alone don't prove this, since OperationCanceledException can unwrap specially).
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task SendAsync_HandlerThrowsNonCancellationException_PropagatesUnwrapped()
+    {
+        await using var fx = await BuildAsync(cfg => cfg.AddHandler(typeof(ThrowingFinalHandler)));
+
+        var mediator = fx.Get<IMediator>();
+
+        await Wrap.It(async () =>
+                await mediator.SendAsync<One>(new Base { Value = "base" }, TestContext.Current.CancellationToken)
+            )
+            .ThrowsAsync<FormatException>();
+    }
+
+    /// <summary>
+    /// Tests that when <see cref="MediatorConfiguration.AddMatch"/> remaps the output type but no handler is
+    /// registered for the resulting (request, resolved-response) pair, <c>SendAsync</c>
+    /// throws <see cref="InvalidOperationException"/>.
+    /// ChainBuilder.ResolveOutput successfully maps <c>IResponse</c> to <c>Response&lt;IBooleanResult&lt;Base&gt;&gt;</c>,
+    /// then the handler loop finds no match and throws before any handler body runs.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task SendAsync_MatchRemappedOutputHasNoHandler_Throws()
+    {
+        await using var fx = await BuildAsync(cfg =>
+            cfg.AddMatch(typeof(Request<Two>), typeof(IResponse), typeof(Response<IBooleanResult<Base>>))
+        );
+
+        var mediator = fx.Get<IMediator>();
+        var payload = new Request<Two>(new Two { Second = 2, Value = "x" });
+
+        await Wrap.It(async () => await mediator.SendAsync<IResponse>(payload, TestContext.Current.CancellationToken))
+            .ThrowsAsync<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// Tests that a passthrough pipe handler (same input and output types as the final handler) is placed
+    /// first in the chain and correctly delegates to the closed final handler, returning the expected result.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task SendAsync_PassthroughSameTypePipe_ReturnsFinalResult()
+    {
+        await using var fx = await BuildAsync(cfg =>
+            cfg.AddHandler(typeof(PassthroughPipeHandler)).AddHandler(typeof(ClosedFinalHandler))
+        );
+
+        var mediator = fx.Get<IMediator>();
+        var request = new Base { Value = "x" };
+
+        var response = await mediator.SendAsync<One>(request, TestContext.Current.CancellationToken);
+
+        AssertClosedHandlerResult(response, request);
     }
 
     /// <summary>
@@ -137,6 +694,17 @@ public class MediatorTest
     private sealed class Fixture(ITestOutputHelper outputHelper) : TestBase(outputHelper), IAsyncDisposable
     {
         /// <summary>
+        /// Registers the request validators (<see cref="Func{One, Boolean}"/> / <see cref="Func{Two, Boolean}"/>)
+        /// that <see cref="ValidationHandler{TRequest, TResponse}"/> resolves. Shared by every test fixture setup.
+        /// </summary>
+        /// <param name="container">The service container to register into.</param>
+        public static void RegisterValidators(IServiceContainer container)
+        {
+            container.Add<Func<One, bool>>(value => value.First % 2 == 1).AsSelf().Singleton();
+            container.Add<Func<Two, bool>>(value => value.Second % 2 == 0).AsSelf().Singleton();
+        }
+
+        /// <summary>
         /// Registers mediator handlers + validators + logging routes. Must be called before
         /// <see cref="Annium.Testing.TestBase.InitializeAsync"/>.
         /// </summary>
@@ -145,8 +713,7 @@ public class MediatorTest
         {
             Register(container =>
             {
-                container.Add<Func<One, bool>>(value => value.First % 2 == 1).AsSelf().Singleton();
-                container.Add<Func<Two, bool>>(value => value.Second % 2 == 0).AsSelf().Singleton();
+                RegisterValidators(container);
                 container.AddMediatorConfiguration(configure);
                 container.AddMediator();
             });
@@ -159,6 +726,7 @@ public class MediatorTest
                             || m.SubjectType.StartsWith("ValidationHandler")
                             || m.SubjectType.StartsWith("OpenFinalHandler")
                             || m.SubjectType.StartsWith("ClosedFinalHandler")
+                            || m.SubjectType.StartsWith("PassthroughPipeHandler")
                         )
                         .UseInMemory<DefaultLogContext>()
                 );
@@ -175,9 +743,6 @@ public class MediatorTest
         : IPipeRequestHandler<Request<TRequest>, TRequest, TResponse, Response<TResponse>>,
             ILogSubject
     {
-        /// <summary>JSON serializer options configured for operations serialization.</summary>
-        private readonly JsonSerializerOptions _options = new JsonSerializerOptions().ConfigureForOperations();
-
         /// <summary>Gets the logger for this handler.</summary>
         public ILogger Logger { get; }
 
@@ -204,6 +769,7 @@ public class MediatorTest
         )
         {
             this.Trace<string>("Deserialize Request to {request}", typeof(TRequest).FriendlyName());
+            // test payloads always serialize to non-null JSON; TRequest is unconstrained so NotNull() can't bind here
             var payload = JsonSerializer.Deserialize<TRequest>(request.Value, _options)!;
 
             var result = await next(payload, ct);
@@ -217,9 +783,6 @@ public class MediatorTest
     /// <typeparam name="T">The type of the request value.</typeparam>
     private class Request<T>
     {
-        /// <summary>JSON serializer options configured for operations serialization.</summary>
-        private readonly JsonSerializerOptions _options = new JsonSerializerOptions().ConfigureForOperations();
-
         /// <summary>Gets the serialized value.</summary>
         public string Value { get; }
 
@@ -234,15 +797,13 @@ public class MediatorTest
     /// <typeparam name="T">The type of the response value.</typeparam>
     private class Response<T> : IResponse
     {
-        /// <summary>JSON serializer options configured for operations deserialization.</summary>
-        private readonly JsonSerializerOptions _options = new JsonSerializerOptions().ConfigureForOperations();
-
         /// <summary>Gets the deserialized value.</summary>
         public T Value { get; }
 
         /// <summary>Initializes a new instance of the <see cref="Response{T}"/> class.</summary>
         public Response(string value)
         {
+            // test payloads always serialize to non-null JSON; T is unconstrained so NotNull() can't bind here
             Value = JsonSerializer.Deserialize<T>(value, _options)!;
         }
     }
@@ -282,6 +843,7 @@ public class MediatorTest
         )
         {
             this.Trace<string>("Start {request} validation", typeof(TRequest).FriendlyName());
+            // default(TResponse)! is a placeholder: Data is discarded on success (overwritten below) and unused on failure
             var result = _validate(request)
                 ? Result.Success(default(TResponse)!)
                 : Result.Failure(default(TResponse)!).Error("Validation failed");
@@ -324,7 +886,7 @@ public class MediatorTest
             this.Info<string>("handler: {type}", GetType().FriendlyName());
             this.Trace<int>("request hash: {hash}", request.GetHashCode());
 
-            var response = new TResponse { Value = request.Value!.Replace(' ', '_') };
+            var response = new TResponse { Value = request.Value.NotNull().Replace(' ', '_') };
 
             return Task.FromResult(response);
         }
@@ -350,12 +912,174 @@ public class MediatorTest
         /// <returns>A task that resolves to the mapped <see cref="One"/> response.</returns>
         public Task<One> HandleAsync(Base request, CancellationToken ct)
         {
-            this.Trace<string>("handler: {type}", GetType().FullName!);
+            this.Trace<string>("handler: {type}", GetType().FullName.NotNull());
             this.Trace<int>("request hash: {hash}", request.GetHashCode());
 
-            return Task.FromResult(new One { First = request.Value!.Length, Value = request.Value });
+            return Task.FromResult(MapBaseToOne(request));
         }
     }
+
+    /// <summary>Final handler that throws a non-cancellation exception, to verify unwrapped exception propagation.</summary>
+    private class ThrowingFinalHandler : IFinalRequestHandler<Base, One>, ILogSubject
+    {
+        /// <summary>Gets the logger for this handler.</summary>
+        public ILogger Logger { get; }
+
+        /// <summary>Initializes a new instance of the <see cref="ThrowingFinalHandler"/> class.</summary>
+        public ThrowingFinalHandler(ILogger logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>Always throws <see cref="FormatException"/> to exercise unwrapped exception propagation.</summary>
+        /// <param name="request">The base request (unused).</param>
+        /// <param name="ct">A cancellation token (unused).</param>
+        /// <returns>Never returns; always throws.</returns>
+        public Task<One> HandleAsync(Base request, CancellationToken ct) => throw new FormatException("boom");
+    }
+
+    /// <summary>
+    /// Final handler that honours cancellation: throws <see cref="OperationCanceledException"/> if the
+    /// token is already cancelled before processing begins.
+    /// </summary>
+    private class CancelObservingFinalHandler : IFinalRequestHandler<Base, One>, ILogSubject
+    {
+        /// <summary>Gets the logger for this handler.</summary>
+        public ILogger Logger { get; }
+
+        /// <summary>Initializes a new instance of the <see cref="CancelObservingFinalHandler"/> class.</summary>
+        public CancelObservingFinalHandler(ILogger logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        /// Throws <see cref="OperationCanceledException"/> when the cancellation token is signalled,
+        /// otherwise maps <see cref="Base"/> to <see cref="One"/>.
+        /// </summary>
+        /// <param name="request">The base request.</param>
+        /// <param name="ct">A cancellation token to observe.</param>
+        /// <returns>A task that resolves to the mapped <see cref="One"/> response.</returns>
+        public Task<One> HandleAsync(Base request, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(MapBaseToOne(request));
+        }
+    }
+
+    /// <summary>
+    /// Pipe handler that honours cancellation: throws <see cref="OperationCanceledException"/> before
+    /// delegating to the next handler when the token is already cancelled. Used to verify that
+    /// <see cref="System.Reflection.BindingFlags.DoNotWrapExceptions"/> applies on the pipe-handler
+    /// (hasNext=true) branch of <see cref="Internal.ChainExecutor"/>.
+    /// </summary>
+    private class CancelObservingPipeHandler : IPipeRequestHandler<Base, Base, One, One>, ILogSubject
+    {
+        /// <summary>Gets the logger for this handler.</summary>
+        public ILogger Logger { get; }
+
+        /// <summary>Initializes a new instance of the <see cref="CancelObservingPipeHandler"/> class.</summary>
+        public CancelObservingPipeHandler(ILogger logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        /// Throws <see cref="OperationCanceledException"/> when the cancellation token is signalled,
+        /// otherwise delegates to the next handler in the pipeline.
+        /// </summary>
+        /// <param name="request">The base request.</param>
+        /// <param name="ct">A cancellation token to observe.</param>
+        /// <param name="next">The next handler delegate in the pipeline.</param>
+        /// <returns>A task that resolves to the <see cref="One"/> response.</returns>
+        public Task<One> HandleAsync(Base request, CancellationToken ct, Func<Base, CancellationToken, Task<One>> next)
+        {
+            ct.ThrowIfCancellationRequested();
+            return next(request, ct);
+        }
+    }
+
+    /// <summary>
+    /// Pipe handler that passes the request through to the next handler unchanged (same-type pipe).
+    /// Used to verify that ChainBuilder picks a same-type pipe as the first chain element and
+    /// that it correctly advances to the final handler.
+    /// </summary>
+    private class PassthroughPipeHandler : IPipeRequestHandler<Base, Base, One, One>, ILogSubject
+    {
+        /// <summary>Gets the logger for this handler.</summary>
+        public ILogger Logger { get; }
+
+        /// <summary>Initializes a new instance of the <see cref="PassthroughPipeHandler"/> class.</summary>
+        public PassthroughPipeHandler(ILogger logger)
+        {
+            Logger = logger;
+        }
+
+        /// <summary>
+        /// Delegates the request to the next handler in the pipeline without modification.
+        /// </summary>
+        /// <param name="request">The base request.</param>
+        /// <param name="ct">A cancellation token to observe.</param>
+        /// <param name="next">The next handler delegate in the pipeline.</param>
+        /// <returns>A task that resolves to the <see cref="One"/> response from the next handler.</returns>
+        public Task<One> HandleAsync(
+            Base request,
+            CancellationToken ct,
+            Func<Base, CancellationToken, Task<One>> next
+        ) => next(request, ct);
+    }
+
+    /// <summary>
+    /// Singleton collector that records the per-instance <see cref="Guid"/> of every
+    /// <see cref="ScopeProbeHandler"/> that handled a request.
+    /// </summary>
+    private sealed class InstanceCollector
+    {
+        /// <summary>Gets the ordered list of instance identifiers captured during test execution.</summary>
+        public System.Collections.Generic.List<Guid> Ids { get; } = new();
+    }
+
+    /// <summary>
+    /// Scoped final handler that records its own instance identifier in <see cref="InstanceCollector"/>
+    /// on every invocation. Because the handler is Scoped, a fresh instance (and thus a fresh
+    /// <see cref="Guid"/>) is created for each <c>SendAsync</c> call that opens a new scope.
+    /// </summary>
+    private class ScopeProbeHandler : IFinalRequestHandler<Base, One>, ILogSubject
+    {
+        /// <summary>Gets the logger for this handler.</summary>
+        public ILogger Logger { get; }
+
+        /// <summary>Unique identifier assigned when this instance is created.</summary>
+        private readonly Guid _id = Guid.NewGuid();
+
+        /// <summary>The singleton collector shared across all handler instances.</summary>
+        private readonly InstanceCollector _collector;
+
+        /// <summary>Initializes a new instance of the <see cref="ScopeProbeHandler"/> class.</summary>
+        public ScopeProbeHandler(InstanceCollector collector, ILogger logger)
+        {
+            _collector = collector;
+            Logger = logger;
+        }
+
+        /// <summary>
+        /// Records <see cref="_id"/> in <see cref="_collector"/> and maps <see cref="Base"/> to <see cref="One"/>.
+        /// </summary>
+        /// <param name="request">The base request.</param>
+        /// <param name="ct">A cancellation token (unused but required by the interface).</param>
+        /// <returns>A task that resolves to the mapped <see cref="One"/> response.</returns>
+        public Task<One> HandleAsync(Base request, CancellationToken ct)
+        {
+            _collector.Ids.Add(_id);
+            return Task.FromResult(MapBaseToOne(request));
+        }
+    }
+
+    /// <summary>Maps a <see cref="Base"/> request to a <see cref="One"/> response (shared by the final test handlers).</summary>
+    /// <param name="request">The base request whose value is mapped.</param>
+    /// <returns>A <see cref="One"/> whose <see cref="One.First"/> is the value length and whose value is the request value.</returns>
+    private static One MapBaseToOne(Base request) =>
+        new() { First = request.Value.NotNull().Length, Value = request.Value };
 
     /// <summary>Base class for test requests and responses.</summary>
     private class Base


### PR DESCRIPTION
- Merge dedups matches across configurations and throws a clear conflict error, fixing a SingleOrDefault "sequence contains more than one element" crash at first dispatch.
- ChainExecutor invokes handlers with BindingFlags.DoNotWrapExceptions so handler exceptions (incl. OperationCanceledException) propagate unwrapped, not as TargetInvocationException.
- Also: concretize fields, extract ThrowIfGeneric/DispatchAsync/test helpers, ConcurrentDictionary chain cache, memoize HandleAsync, ChainElement record->class, fix resolvedType error message; mediator tests 4->28.
- Stabilize flaky DebounceTimer test: widen period 20->80ms and bulk idle 50->200ms so each bulk coalesces to one fire.