### PR TITLE
fix(identity): harden JWT options validation and audience emission

### DIFF
--- a/base/Identity/src/Annium.Identity.Tokens.Jwt/JwtReader.cs
+++ b/base/Identity/src/Annium.Identity.Tokens.Jwt/JwtReader.cs
@@ -22,6 +22,18 @@ public sealed class JwtReader : ITokenReader<ClaimsPrincipal>
     /// <summary>Per-instance handler — <see cref="JwtSecurityTokenHandler"/> read paths are thread-safe.</summary>
     private readonly JwtSecurityTokenHandler _handler = new();
 
+    /// <summary>Message for an expired token, shared by the manual ValidTo check and the exception mapping.</summary>
+    private const string ExpiredMessage = "Token is expired";
+
+    /// <summary>Message for a not-yet-valid token, shared by the manual ValidFrom check and the exception mapping.</summary>
+    private const string NotYetValidMessage = "Token is not yet valid";
+
+    /// <summary>Message for an invalid signature, shared by the signature-related exception-mapping arms.</summary>
+    private const string InvalidSignatureMessage = "Token has invalid signature";
+
+    /// <summary>Message for a decryption failure, shared by the encryption-key / decryption exception-mapping arms.</summary>
+    private const string DecryptionFailedMessage = "Token decryption failed";
+
     public JwtReader(JwtTokensOptions options, ITimeProvider time)
     {
         _options = options;
@@ -67,14 +79,10 @@ public sealed class JwtReader : ITokenReader<ClaimsPrincipal>
             {
                 var nowUtc = _time.Now.ToDateTimeUtc();
                 if (jwt.ValidFrom > nowUtc)
-                    return new TokenReadResult<ClaimsPrincipal>(
-                        TokenReadStatus.NotYetValid,
-                        null,
-                        "Token is not yet valid"
-                    );
+                    return new TokenReadResult<ClaimsPrincipal>(TokenReadStatus.NotYetValid, null, NotYetValidMessage);
 
                 if (jwt.ValidTo <= nowUtc)
-                    return new TokenReadResult<ClaimsPrincipal>(TokenReadStatus.Expired, null, "Token is expired");
+                    return new TokenReadResult<ClaimsPrincipal>(TokenReadStatus.Expired, null, ExpiredMessage);
             }
 
             var identity = new ClaimsIdentity(jwt.Claims, "JWT");
@@ -154,21 +162,18 @@ public sealed class JwtReader : ITokenReader<ClaimsPrincipal>
     private static (TokenReadStatus status, string message) MapValidationFailure(Exception ex) =>
         ex switch
         {
-            SecurityTokenExpiredException => (TokenReadStatus.Expired, "Token is expired"),
-            SecurityTokenNotYetValidException => (TokenReadStatus.NotYetValid, "Token is not yet valid"),
+            SecurityTokenExpiredException => (TokenReadStatus.Expired, ExpiredMessage),
+            SecurityTokenNotYetValidException => (TokenReadStatus.NotYetValid, NotYetValidMessage),
             // SignatureKeyNotFound derives from InvalidSignature, so the more-specific arm comes first.
-            SecurityTokenSignatureKeyNotFoundException => (
-                TokenReadStatus.InvalidSignature,
-                "Token has invalid signature"
-            ),
-            SecurityTokenInvalidSignatureException => (TokenReadStatus.InvalidSignature, "Token has invalid signature"),
+            SecurityTokenSignatureKeyNotFoundException => (TokenReadStatus.InvalidSignature, InvalidSignatureMessage),
+            SecurityTokenInvalidSignatureException => (TokenReadStatus.InvalidSignature, InvalidSignatureMessage),
             SecurityTokenInvalidAudienceException => (TokenReadStatus.InvalidClaims, "Token has invalid audience"),
             SecurityTokenInvalidIssuerException => (TokenReadStatus.InvalidClaims, "Token has invalid issuer"),
             SecurityTokenInvalidLifetimeException => (TokenReadStatus.InvalidClaims, "Token has invalid lifetime"),
             SecurityTokenNoExpirationException => (TokenReadStatus.InvalidClaims, "Token has no expiration claim"),
             SecurityTokenDecompressionFailedException => (TokenReadStatus.Malformed, "Token decompression failed"),
-            SecurityTokenEncryptionKeyNotFoundException => (TokenReadStatus.Malformed, "Token decryption failed"),
-            SecurityTokenDecryptionFailedException => (TokenReadStatus.Malformed, "Token decryption failed"),
+            SecurityTokenEncryptionKeyNotFoundException => (TokenReadStatus.Malformed, DecryptionFailedMessage),
+            SecurityTokenDecryptionFailedException => (TokenReadStatus.Malformed, DecryptionFailedMessage),
             _ => (TokenReadStatus.Unknown, ex.Message),
         };
 }

--- a/base/Identity/src/Annium.Identity.Tokens.Jwt/JwtTokensOptions.cs
+++ b/base/Identity/src/Annium.Identity.Tokens.Jwt/JwtTokensOptions.cs
@@ -11,6 +11,7 @@ namespace Annium.Identity.Tokens.Jwt;
 public sealed class JwtTokensOptions
 {
     /// <summary>Key used both to sign (writer) and verify (reader) the token.</summary>
+    // required — populated by AddJwtTokens' configure delegate before the reader/writer first resolve.
     public SecurityKey SigningKey { get; set; } = null!;
 
     /// <summary>JWT signing algorithm — e.g., <c>SecurityAlgorithms.RsaSha256</c>.</summary>

--- a/base/Identity/src/Annium.Identity.Tokens.Jwt/JwtWriter.cs
+++ b/base/Identity/src/Annium.Identity.Tokens.Jwt/JwtWriter.cs
@@ -48,12 +48,21 @@ public sealed class JwtWriter : ITokenWriter<ClaimsPrincipal>
     {
         var now = _time.Now;
         var lifetime = overrides?.Lifetime ?? _options.Lifetime;
-        var audience = overrides?.Audience ?? _options.Audience ?? string.Empty;
+        // null/empty audience → omit the aud claim entirely (a null JwtPayload audience adds no claim),
+        // honoring JwtTokensOptions.Audience's "null means audience disabled" contract rather than emitting aud="".
+        var audience = overrides?.Audience ?? _options.Audience;
         var issuedAt = now.ToDateTimeUtc();
         var expires = (now + lifetime).ToDateTimeUtc();
 
         var header = new JwtHeader(new SigningCredentials(_options.SigningKey, _options.Algorithm));
-        var payload = new JwtPayload(_options.Issuer, audience, claims.Claims.ToArray(), issuedAt, expires, issuedAt);
+        var payload = new JwtPayload(
+            _options.Issuer,
+            string.IsNullOrEmpty(audience) ? null : audience,
+            claims.Claims.ToArray(),
+            issuedAt,
+            expires,
+            issuedAt
+        );
         var jwt = new JwtSecurityToken(header, payload);
 
         return _handler.WriteToken(jwt);

--- a/base/Identity/src/Annium.Identity.Tokens.Jwt/ServiceContainerExtensions.cs
+++ b/base/Identity/src/Annium.Identity.Tokens.Jwt/ServiceContainerExtensions.cs
@@ -16,6 +16,11 @@ public static class ServiceContainerExtensions
     /// <see cref="ITokenWriter{ClaimsPrincipal}"/> backed by <see cref="JwtReader"/> /
     /// <see cref="JwtWriter"/>, plus the singleton <see cref="JwtTokensOptions"/> they depend on.
     /// </summary>
+    /// <remarks>
+    /// Requires an <c>ITimeProvider</c> to be registered (e.g. via <c>AddTime()...SetDefault()</c> from
+    /// Annium.Core.Runtime) before the provider is built — <see cref="JwtReader"/> and <see cref="JwtWriter"/>
+    /// inject it as the token clock. Registration order is irrelevant; the dependency is resolved at build time.
+    /// </remarks>
     /// <typeparam name="TContainer">Service container type.</typeparam>
     /// <param name="container">The service container.</param>
     /// <param name="configure">Optional delegate to populate <see cref="JwtTokensOptions"/>.</param>
@@ -28,6 +33,21 @@ public static class ServiceContainerExtensions
     {
         var options = new JwtTokensOptions();
         configure?.Invoke(options);
+
+        if (options.SigningKey is null)
+            throw new InvalidOperationException(
+                "JwtTokensOptions.SigningKey must be configured: pass a configure delegate to AddJwtTokens that sets SigningKey."
+            );
+
+        if (string.IsNullOrWhiteSpace(options.Algorithm))
+            throw new InvalidOperationException(
+                "JwtTokensOptions.Algorithm must be configured: pass a configure delegate to AddJwtTokens that sets Algorithm."
+            );
+
+        if (string.IsNullOrWhiteSpace(options.Issuer))
+            throw new InvalidOperationException(
+                "JwtTokensOptions.Issuer must be configured: pass a configure delegate to AddJwtTokens that sets Issuer."
+            );
 
         container.Add(options).AsSelf().Singleton();
         container.Add<ITokenReader<ClaimsPrincipal>, JwtReader>().Singleton();

--- a/base/Identity/src/Annium.Identity.Tokens/AsymmetricAlgorithmExtensions.cs
+++ b/base/Identity/src/Annium.Identity.Tokens/AsymmetricAlgorithmExtensions.cs
@@ -10,6 +10,12 @@ namespace Annium.Identity.Tokens;
 /// </summary>
 public static class AsymmetricAlgorithmExtensions
 {
+    /// <summary>Number of groups in a key-id fingerprint (12 × 4 = 240 bits of the SHA-256 hash).</summary>
+    private const int KeyIdGroupCount = 12;
+
+    /// <summary>Character width of each key-id fingerprint group.</summary>
+    private const int KeyIdGroupSize = 4;
+
     /// <summary>
     /// Imports a PEM-formatted key into the algorithm
     /// </summary>
@@ -37,9 +43,13 @@ public static class AsymmetricAlgorithmExtensions
         var kidBase32 = Base32.Rfc4648.Encode(kidHash);
         var chunks = new List<string>();
 
-        for (var i = 0; i < 12; i++)
+        // Fixed-length fingerprint: the 32-byte SHA-256 hash base32-encodes to 52 chars; we take the
+        // first 12 groups of 4 (240 bits) and join them as XXXX:...:XXXX. The 12-group format is a
+        // deliberate, stable key-id shape (pinned by tests) — 240 bits is far beyond any collision
+        // concern, so dropping the final chars is intentional, not truncation of needed entropy.
+        for (var i = 0; i < KeyIdGroupCount; i++)
         {
-            chunks.Add(kidBase32[(i * 4)..(i * 4 + 4)]);
+            chunks.Add(kidBase32[(i * KeyIdGroupSize)..(i * KeyIdGroupSize + KeyIdGroupSize)]);
         }
 
         return string.Join(':', chunks);

--- a/base/Identity/tests/Annium.Identity.Tokens.Jwt.Tests/JwtReaderWriterEcdsaTests.cs
+++ b/base/Identity/tests/Annium.Identity.Tokens.Jwt.Tests/JwtReaderWriterEcdsaTests.cs
@@ -1,6 +1,12 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
 using System.IO;
+using System.Linq;
+using System.Security.Claims;
 using System.Security.Cryptography;
+using Annium.Testing;
 using Microsoft.IdentityModel.Tokens;
+using NodaTime;
 using Xunit;
 
 namespace Annium.Identity.Tokens.Jwt.Tests;
@@ -18,8 +24,7 @@ public class JwtReaderWriterEcdsaTests : JwtReaderWriterTestsBase
     [Fact]
     public void Works()
     {
-        var privateKey = ECDsa.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "ecdsa_private.pem"))).GetKey();
-        var publicKey = ECDsa.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "ecdsa_public.pem"))).GetKey();
+        var (privateKey, publicKey) = CreateKeys();
 
         Works_Base(privateKey, publicKey, SecurityAlgorithms.EcdsaSha512);
     }
@@ -30,8 +35,7 @@ public class JwtReaderWriterEcdsaTests : JwtReaderWriterTestsBase
     [Fact]
     public void Expired_ExpirationWindowNull_Fails()
     {
-        var privateKey = ECDsa.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "ecdsa_private.pem"))).GetKey();
-        var publicKey = ECDsa.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "ecdsa_public.pem"))).GetKey();
+        var (privateKey, publicKey) = CreateKeys();
 
         Expired_ExpirationWindowNull_Base(privateKey, publicKey, SecurityAlgorithms.EcdsaSha512);
     }
@@ -42,8 +46,7 @@ public class JwtReaderWriterEcdsaTests : JwtReaderWriterTestsBase
     [Fact]
     public void Expired_ExpirationWindow_Fails()
     {
-        var privateKey = ECDsa.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "ecdsa_private.pem"))).GetKey();
-        var publicKey = ECDsa.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "ecdsa_public.pem"))).GetKey();
+        var (privateKey, publicKey) = CreateKeys();
 
         Expired_ExpirationWindow_Base(privateKey, publicKey, SecurityAlgorithms.EcdsaSha512);
     }
@@ -52,8 +55,7 @@ public class JwtReaderWriterEcdsaTests : JwtReaderWriterTestsBase
     [Fact]
     public void Read_WithAudienceValidationDisabled_AcceptsAudienceMismatch()
     {
-        var privateKey = ECDsa.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "ecdsa_private.pem"))).GetKey();
-        var publicKey = ECDsa.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "ecdsa_public.pem"))).GetKey();
+        var (privateKey, publicKey) = CreateKeys();
 
         Read_WithAudienceValidationDisabled_AcceptsAudienceMismatch_Base(
             privateKey,
@@ -66,8 +68,7 @@ public class JwtReaderWriterEcdsaTests : JwtReaderWriterTestsBase
     [Fact]
     public void Read_WithLifetimeValidationDisabled_AcceptsExpiredToken()
     {
-        var privateKey = ECDsa.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "ecdsa_private.pem"))).GetKey();
-        var publicKey = ECDsa.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "ecdsa_public.pem"))).GetKey();
+        var (privateKey, publicKey) = CreateKeys();
 
         Read_WithLifetimeValidationDisabled_AcceptsExpiredToken_Base(
             privateKey,
@@ -80,7 +81,7 @@ public class JwtReaderWriterEcdsaTests : JwtReaderWriterTestsBase
     [Fact]
     public void Write_WithAudienceOverride_EmitsAudienceClaim()
     {
-        var privateKey = ECDsa.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "ecdsa_private.pem"))).GetKey();
+        var privateKey = LoadPrivateKey();
 
         Write_WithAudienceOverride_EmitsAudienceClaim_Base(privateKey, SecurityAlgorithms.EcdsaSha512);
     }
@@ -89,8 +90,329 @@ public class JwtReaderWriterEcdsaTests : JwtReaderWriterTestsBase
     [Fact]
     public void Write_WithLifetimeOverride_EmitsCorrectExpClaim()
     {
-        var privateKey = ECDsa.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "ecdsa_private.pem"))).GetKey();
+        var privateKey = LoadPrivateKey();
 
         Write_WithLifetimeOverride_EmitsCorrectExpClaim_Base(privateKey, SecurityAlgorithms.EcdsaSha512);
     }
+
+    /// <summary>
+    /// When no audience is configured and no write override is supplied, the writer must omit the
+    /// <c>aud</c> claim entirely rather than emitting an empty string.
+    /// </summary>
+    [Fact]
+    public void Write_NoAudienceConfigured_OmitsAudClaim()
+    {
+        var (privateKey, _) = CreateKeys();
+        var writer = CreateWriter(privateKey, audience: null);
+
+        var encoded = writer.Write(MinimalPrincipal());
+
+        var jwt = new JwtSecurityTokenHandler().ReadJwtToken(encoded);
+        jwt.Audiences.Any().IsFalse();
+    }
+
+    /// <summary>
+    /// When a <see cref="JwtWriteOverrides"/> is passed with <c>Audience = null</c>, the writer
+    /// falls back to the configured audience rather than suppressing it.
+    /// </summary>
+    [Fact]
+    public void Write_NullAudienceOverride_InheritsConfiguredAudience()
+    {
+        var (privateKey, _) = CreateKeys();
+        var writer = CreateWriter(privateKey, audience: "configured-aud");
+
+        var encoded = writer.Write(MinimalPrincipal(), new JwtWriteOverrides(Audience: null));
+
+        var jwt = new JwtSecurityTokenHandler().ReadJwtToken(encoded);
+        jwt.Audiences.Single().Is("configured-aud");
+    }
+
+    /// <summary>
+    /// An explicit empty-string audience override omits the aud claim — the writer's
+    /// <c>IsNullOrEmpty</c> guard treats <c>""</c> the same as null (no aud claim emitted).
+    /// </summary>
+    [Fact]
+    public void Write_EmptyAudienceOverride_OmitsAudClaim()
+    {
+        var (privateKey, _) = CreateKeys();
+        var writer = CreateWriter(privateKey, audience: "configured-aud");
+
+        var encoded = writer.Write(MinimalPrincipal(), new JwtWriteOverrides(Audience: ""));
+
+        var jwt = new JwtSecurityTokenHandler().ReadJwtToken(encoded);
+        jwt.Audiences.Any().IsFalse();
+    }
+
+    /// <summary>
+    /// Passing <c>ValidateAudience: true</c> when the reader has no configured audience must throw
+    /// <see cref="InvalidOperationException"/> before any token validation occurs.
+    /// </summary>
+    [Fact]
+    public void Read_ForceAudienceValidationWithoutConfiguredAudience_Throws()
+    {
+        var (privateKey, publicKey) = CreateKeys();
+        var writer = CreateWriter(privateKey, audience: null);
+        var reader = CreateReader(publicKey, audience: null, expirationWindow: Duration.FromSeconds(10));
+
+        var encoded = writer.Write(MinimalPrincipal());
+
+        Wrap.It(() => reader.Read(encoded, new JwtReadOverrides(ValidateAudience: true)))
+            .Throws<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// Passing <c>ValidateLifetime: true</c> when the reader has no configured expiration window
+    /// must throw <see cref="InvalidOperationException"/> before any token validation occurs.
+    /// </summary>
+    [Fact]
+    public void Read_ForceLifetimeValidationWithoutConfiguredWindow_Throws()
+    {
+        var (privateKey, publicKey) = CreateKeys();
+        var writer = CreateWriter(privateKey, audience: "audience");
+        var reader = CreateReader(publicKey, audience: "audience", expirationWindow: null);
+
+        var encoded = writer.Write(MinimalPrincipal());
+
+        Wrap.It(() => reader.Read(encoded, new JwtReadOverrides(ValidateLifetime: true)))
+            .Throws<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// A token signed with key-pair A must produce <see cref="TokenReadStatus.InvalidSignature"/>
+    /// when read by a reader configured with a different, unrelated public key.
+    /// </summary>
+    [Fact]
+    public void Read_WrongSigningKey_ReturnsInvalidSignature()
+    {
+        var (privateKey, _) = CreateKeys();
+        var writer = CreateWriter(privateKey, audience: "audience");
+
+        var encoded = writer.Write(MinimalPrincipal());
+
+        // Deliberately use a freshly generated key that has no relation to the signing key.
+        var wrongKey = ECDsa.Create().GetKey();
+        var reader = CreateReader(wrongKey, audience: "audience", expirationWindow: Duration.FromSeconds(10));
+
+        var result = reader.Read(encoded);
+
+        result.Status.Is(TokenReadStatus.InvalidSignature);
+        result.Claims.IsNull();
+        result.Error.IsNotNull();
+    }
+
+    /// <summary>
+    /// A token whose issuer does not match the reader's configured issuer must return
+    /// <see cref="TokenReadStatus.InvalidClaims"/>.
+    /// </summary>
+    [Fact]
+    public void Read_InvalidIssuer_ReturnsInvalidClaims()
+    {
+        var (privateKey, publicKey) = CreateKeys();
+        var writer = CreateWriter(privateKey, audience: "audience");
+        var reader = CreateReader(
+            publicKey,
+            audience: "audience",
+            expirationWindow: Duration.FromSeconds(10),
+            issuer: "other-issuer"
+        );
+
+        var encoded = writer.Write(MinimalPrincipal());
+        var result = reader.Read(encoded);
+
+        result.Status.Is(TokenReadStatus.InvalidClaims);
+        result.Claims.IsNull();
+        result.Error.IsNotNull();
+    }
+
+    /// <summary>
+    /// A string without JWT structure (rejected by the CanReadToken guard) must be mapped to
+    /// <see cref="TokenReadStatus.Malformed"/> rather than throwing an exception.
+    /// </summary>
+    [Fact]
+    public void Read_MalformedString_ReturnsMalformed()
+    {
+        var (_, publicKey) = CreateKeys();
+        var reader = CreateReader(publicKey, audience: "audience", expirationWindow: Duration.FromSeconds(10));
+
+        // No dot-separated segments → CanReadToken rejects it → Malformed (the documented guard path).
+        var result = reader.Read("not-a-jwt");
+
+        result.Status.Is(TokenReadStatus.Malformed);
+        result.Claims.IsNull();
+        result.Error.IsNotNull();
+    }
+
+    /// <summary>
+    /// A token whose <c>nbf</c> is in the future must return <see cref="TokenReadStatus.NotYetValid"/>
+    /// via the reader's manual ValidFrom check (exercised when ExpirationWindow is null, so the MS
+    /// library skips its own lifetime validation).
+    /// </summary>
+    [Fact]
+    public void Read_TokenNotYetValid_ReturnsNotYetValid()
+    {
+        var (privateKey, publicKey) = CreateKeys();
+        var now = DateTime.UtcNow;
+
+        // The writer always stamps nbf = now, so it cannot produce a not-yet-valid token; craft one
+        // directly with a future nbf, signed with the private key the reader trusts.
+        var header = new JwtHeader(new SigningCredentials(privateKey, SecurityAlgorithms.EcdsaSha512));
+        var payload = new JwtPayload(
+            "service",
+            "audience",
+            new[] { new Claim("k", "v") },
+            notBefore: now.AddHours(1),
+            expires: now.AddHours(2),
+            issuedAt: now
+        );
+        var encoded = new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(header, payload));
+
+        // ExpirationWindow = null → MS skips lifetime validation → the manual ValidFrom check runs.
+        var reader = CreateReader(publicKey, audience: "audience", expirationWindow: null);
+
+        var result = reader.Read(encoded);
+
+        result.Status.Is(TokenReadStatus.NotYetValid);
+        result.Claims.IsNull();
+        result.Error.IsNotNull();
+    }
+
+    /// <summary>
+    /// With a configured ExpirationWindow (MS lifetime validation on), a future-nbf token makes the
+    /// MS library throw <c>SecurityTokenNotYetValidException</c>, which the reader maps to
+    /// <see cref="TokenReadStatus.NotYetValid"/> via the exception-mapping arm (distinct from the
+    /// manual ValidFrom check exercised when ExpirationWindow is null).
+    /// </summary>
+    [Fact]
+    public void Read_TokenNotYetValid_WithExpirationWindow_ReturnsNotYetValid()
+    {
+        var (privateKey, publicKey) = CreateKeys();
+        var now = DateTime.UtcNow;
+
+        var header = new JwtHeader(new SigningCredentials(privateKey, SecurityAlgorithms.EcdsaSha512));
+        var payload = new JwtPayload(
+            "service",
+            "audience",
+            new[] { new Claim("k", "v") },
+            notBefore: now.AddHours(1),
+            expires: now.AddHours(2),
+            issuedAt: now
+        );
+        var encoded = new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(header, payload));
+
+        // Non-null ExpirationWindow → MS validates lifetime and throws on the future nbf.
+        var reader = CreateReader(publicKey, audience: "audience", expirationWindow: Duration.FromSeconds(10));
+
+        var result = reader.Read(encoded);
+
+        result.Status.Is(TokenReadStatus.NotYetValid);
+        result.Claims.IsNull();
+        result.Error.IsNotNull();
+    }
+
+    /// <summary>
+    /// With no configured ExpirationWindow, an explicit <c>ValidateLifetime: false</c> override must
+    /// accept an already-expired token: both the MS lifetime check and the manual ValidFrom/ValidTo
+    /// check are suppressed (the refresh-token-on-unconfigured-window path).
+    /// </summary>
+    [Fact]
+    public void Read_LifetimeValidationDisabledWithoutWindow_AcceptsExpiredToken()
+    {
+        var (privateKey, publicKey) = CreateKeys();
+        var now = DateTime.UtcNow;
+
+        // The writer always stamps exp = now + lifetime, so craft an already-expired token directly.
+        var header = new JwtHeader(new SigningCredentials(privateKey, SecurityAlgorithms.EcdsaSha512));
+        var payload = new JwtPayload(
+            "service",
+            "audience",
+            new[] { new Claim("k", "v") },
+            notBefore: now.AddHours(-2),
+            expires: now.AddHours(-1),
+            issuedAt: now.AddHours(-2)
+        );
+        var encoded = new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(header, payload));
+
+        var reader = CreateReader(publicKey, audience: "audience", expirationWindow: null);
+
+        var result = reader.Read(encoded, new JwtReadOverrides(ValidateLifetime: false));
+
+        result.Status.Is(TokenReadStatus.Ok);
+    }
+
+    /// <summary>
+    /// Builds an ECDSA-signing <see cref="JwtWriter"/> over a fresh real-time provider, with the
+    /// algorithm fixed to ECDSA-SHA512 and the issuer defaulting to <c>"service"</c>.
+    /// </summary>
+    /// <param name="key">Signing key.</param>
+    /// <param name="audience">Configured audience (null = none emitted).</param>
+    /// <param name="issuer">Token issuer.</param>
+    /// <param name="lifetime">Token lifetime (defaults to 45 seconds).</param>
+    /// <returns>The configured writer.</returns>
+    private static JwtWriter CreateWriter(
+        SecurityKey key,
+        string? audience,
+        string issuer = "service",
+        Duration? lifetime = null
+    ) =>
+        new(
+            new JwtTokensOptions
+            {
+                SigningKey = key,
+                Algorithm = SecurityAlgorithms.EcdsaSha512,
+                Issuer = issuer,
+                Audience = audience,
+                Lifetime = lifetime ?? Duration.FromSeconds(45),
+            },
+            ResolveTime()
+        );
+
+    /// <summary>
+    /// Builds an ECDSA-verifying <see cref="JwtReader"/> over a fresh real-time provider, with the
+    /// algorithm fixed to ECDSA-SHA512 and the issuer defaulting to <c>"service"</c>.
+    /// </summary>
+    /// <param name="key">Verification key.</param>
+    /// <param name="audience">Configured audience (null = audience check disabled).</param>
+    /// <param name="expirationWindow">Clock-skew tolerance (null = manual ValidFrom/ValidTo check).</param>
+    /// <param name="issuer">Expected issuer.</param>
+    /// <returns>The configured reader.</returns>
+    private static JwtReader CreateReader(
+        SecurityKey key,
+        string? audience,
+        Duration? expirationWindow,
+        string issuer = "service"
+    ) =>
+        new(
+            new JwtTokensOptions
+            {
+                SigningKey = key,
+                Algorithm = SecurityAlgorithms.EcdsaSha512,
+                Issuer = issuer,
+                Audience = audience,
+                ExpirationWindow = expirationWindow,
+                Lifetime = Duration.FromSeconds(45),
+            },
+            ResolveTime()
+        );
+
+    /// <summary>
+    /// Loads the ECDSA private/public key pair from the test fixture PEM files. The created
+    /// <see cref="ECDsa"/> instances are intentionally not disposed — Microsoft.IdentityModel caches
+    /// signature providers by KeyId for the process lifetime, so disposing them breaks later tests.
+    /// </summary>
+    /// <returns>The private and public ECDSA security keys.</returns>
+    private static (ECDsaSecurityKey privateKey, ECDsaSecurityKey publicKey) CreateKeys()
+    {
+        var privateKey = LoadPrivateKey();
+        var publicKey = ECDsa.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "ecdsa_public.pem"))).GetKey();
+
+        return (privateKey, publicKey);
+    }
+
+    /// <summary>
+    /// Loads the ECDSA private key from the test fixture PEM file. The created <see cref="ECDsa"/> is
+    /// intentionally not disposed (see <see cref="CreateKeys"/> for the rationale).
+    /// </summary>
+    /// <returns>The private ECDSA security key.</returns>
+    private static ECDsaSecurityKey LoadPrivateKey() =>
+        ECDsa.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "ecdsa_private.pem"))).GetKey();
 }

--- a/base/Identity/tests/Annium.Identity.Tokens.Jwt.Tests/JwtReaderWriterRsaTests.cs
+++ b/base/Identity/tests/Annium.Identity.Tokens.Jwt.Tests/JwtReaderWriterRsaTests.cs
@@ -18,8 +18,7 @@ public class JwtReaderWriterRsaTests : JwtReaderWriterTestsBase
     [Fact]
     public void Works()
     {
-        var privateKey = RSA.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "rsa_private.pem"))).GetKey();
-        var publicKey = RSA.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "rsa_public.pem"))).GetKey();
+        var (privateKey, publicKey) = CreateKeys();
 
         Works_Base(privateKey, publicKey, SecurityAlgorithms.RsaSha256);
     }
@@ -30,8 +29,7 @@ public class JwtReaderWriterRsaTests : JwtReaderWriterTestsBase
     [Fact]
     public void Expired_ExpirationWindowNull_Fails()
     {
-        var privateKey = RSA.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "rsa_private.pem"))).GetKey();
-        var publicKey = RSA.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "rsa_public.pem"))).GetKey();
+        var (privateKey, publicKey) = CreateKeys();
 
         Expired_ExpirationWindowNull_Base(privateKey, publicKey, SecurityAlgorithms.RsaSha256);
     }
@@ -42,9 +40,66 @@ public class JwtReaderWriterRsaTests : JwtReaderWriterTestsBase
     [Fact]
     public void Expired_ExpirationWindow_Fails()
     {
+        var (privateKey, publicKey) = CreateKeys();
+
+        Expired_ExpirationWindow_Base(privateKey, publicKey, SecurityAlgorithms.RsaSha256);
+    }
+
+    /// <summary>T6.A: ValidateAudience override = false accepts an audience-mismatched token (RSA).</summary>
+    [Fact]
+    public void Read_WithAudienceValidationDisabled_AcceptsAudienceMismatch()
+    {
+        var (privateKey, publicKey) = CreateKeys();
+
+        Read_WithAudienceValidationDisabled_AcceptsAudienceMismatch_Base(
+            privateKey,
+            publicKey,
+            SecurityAlgorithms.RsaSha256
+        );
+    }
+
+    /// <summary>T6.A: ValidateLifetime override = false accepts an expired token (RSA).</summary>
+    [Fact]
+    public void Read_WithLifetimeValidationDisabled_AcceptsExpiredToken()
+    {
+        var (privateKey, publicKey) = CreateKeys();
+
+        Read_WithLifetimeValidationDisabled_AcceptsExpiredToken_Base(
+            privateKey,
+            publicKey,
+            SecurityAlgorithms.RsaSha256
+        );
+    }
+
+    /// <summary>T6.A: Audience override drives the emitted aud claim (RSA).</summary>
+    [Fact]
+    public void Write_WithAudienceOverride_EmitsAudienceClaim()
+    {
+        var (privateKey, _) = CreateKeys();
+
+        Write_WithAudienceOverride_EmitsAudienceClaim_Base(privateKey, SecurityAlgorithms.RsaSha256);
+    }
+
+    /// <summary>T6.A: Lifetime override drives the emitted exp - iat span (RSA).</summary>
+    [Fact]
+    public void Write_WithLifetimeOverride_EmitsCorrectExpClaim()
+    {
+        var (privateKey, _) = CreateKeys();
+
+        Write_WithLifetimeOverride_EmitsCorrectExpClaim_Base(privateKey, SecurityAlgorithms.RsaSha256);
+    }
+
+    /// <summary>
+    /// Loads the RSA private/public key pair from the test fixture PEM files. The created
+    /// <see cref="RSA"/> instances are intentionally not disposed — Microsoft.IdentityModel caches
+    /// signature providers by KeyId for the process lifetime, so disposing them breaks later tests.
+    /// </summary>
+    /// <returns>The private and public RSA security keys.</returns>
+    private static (RsaSecurityKey privateKey, RsaSecurityKey publicKey) CreateKeys()
+    {
         var privateKey = RSA.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "rsa_private.pem"))).GetKey();
         var publicKey = RSA.Create().ImportPem(File.ReadAllText(Path.Combine("keys", "rsa_public.pem"))).GetKey();
 
-        Expired_ExpirationWindow_Base(privateKey, publicKey, SecurityAlgorithms.RsaSha256);
+        return (privateKey, publicKey);
     }
 }

--- a/base/Identity/tests/Annium.Identity.Tokens.Jwt.Tests/JwtReaderWriterTestsBase.cs
+++ b/base/Identity/tests/Annium.Identity.Tokens.Jwt.Tests/JwtReaderWriterTestsBase.cs
@@ -104,13 +104,13 @@ public class JwtReaderWriterTestsBase
 
         // assert - encoded is non-empty
         encoded.IsNotDefault();
-        encoded.Length.Is(encoded.Length); // sanity (used to silence unused-var)
 
         // act - read
         var result = reader.Read(encoded);
 
         // assert - read
         result.Status.Is(TokenReadStatus.Ok);
+        result.Error.IsNull();
         result.Claims.IsNotDefault();
         var claims = result.Claims!.Claims.ToArray();
         claims.FirstOrDefault(c => c.Type == "jti").IsNotDefault().Value.Is(tokenId);
@@ -134,7 +134,7 @@ public class JwtReaderWriterTestsBase
         string signatureAlgorithm
     )
     {
-        // arrange — write a token with a 1-hour past lifetime
+        // arrange — write a token with a 1 ms lifetime so it expires almost immediately
         var issuer = "service";
         var audience = "audience";
         var lifetime = Duration.FromMilliseconds(1); // immediately expires
@@ -147,7 +147,7 @@ public class JwtReaderWriterTestsBase
             Duration.FromSeconds(10),
             lifetime
         );
-        var encoded = writer.Write(new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("k", "v") }, "JWT")));
+        var encoded = writer.Write(MinimalPrincipal());
 
         // wait so the token's ValidTo (now + 1ms) is in the past
         Thread.Sleep(50);
@@ -186,11 +186,10 @@ public class JwtReaderWriterTestsBase
             Duration.FromSeconds(10),
             lifetime
         );
-        var encoded = writer.Write(new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("k", "v") }, "JWT")));
+        var encoded = writer.Write(MinimalPrincipal());
 
-        // wait so the token expires (lifetime 1ms) plus ClockSkew (10s applied below) — need
-        // to wait > 10s for the MS library to treat it as expired. We use a tighter
-        // ClockSkew here (1ms) so the test stays fast.
+        // wait until the token (1 ms lifetime + 1 ms ClockSkew on the reader configured below) is
+        // past expiry, so the MS library treats it as expired and the reader maps that to Expired.
         Thread.Sleep(50);
 
         var (reader, _, _) = Resolve(
@@ -249,7 +248,7 @@ public class JwtReaderWriterTestsBase
             time
         );
 
-        var encoded = writer.Write(new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("k", "v") }, "JWT")));
+        var encoded = writer.Write(MinimalPrincipal());
 
         // sanity — without override the read must fail (audience mismatch)
         reader.Read(encoded).Status.Is(TokenReadStatus.InvalidClaims);
@@ -302,7 +301,7 @@ public class JwtReaderWriterTestsBase
             time
         );
 
-        var encoded = writer.Write(new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("k", "v") }, "JWT")));
+        var encoded = writer.Write(MinimalPrincipal());
 
         // wait long enough that ValidTo + ClockSkew has passed even under concurrent test load
         Thread.Sleep(500);
@@ -340,10 +339,7 @@ public class JwtReaderWriterTestsBase
         );
 
         // act
-        var encoded = writer.Write(
-            new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("k", "v") }, "JWT")),
-            new JwtWriteOverrides(Audience: "per-call-aud")
-        );
+        var encoded = writer.Write(MinimalPrincipal(), new JwtWriteOverrides(Audience: "per-call-aud"));
 
         // assert — decoded aud claim is the per-call override
         var jwt = new JwtSecurityTokenHandler().ReadJwtToken(encoded);
@@ -376,10 +372,7 @@ public class JwtReaderWriterTestsBase
         );
 
         // act
-        var encoded = writer.Write(
-            new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("k", "v") }, "JWT")),
-            new JwtWriteOverrides(Lifetime: Duration.FromHours(2))
-        );
+        var encoded = writer.Write(MinimalPrincipal(), new JwtWriteOverrides(Lifetime: Duration.FromHours(2)));
 
         // assert — decoded ValidTo - ValidFrom matches the per-call override (modulo 1s rounding)
         var jwt = new JwtSecurityTokenHandler().ReadJwtToken(encoded);
@@ -394,10 +387,18 @@ public class JwtReaderWriterTestsBase
     /// concrete <see cref="JwtReader"/> / <see cref="JwtWriter"/> instances directly.
     /// </summary>
     /// <returns>The resolved time provider.</returns>
-    private static ITimeProvider ResolveTime()
+    protected static ITimeProvider ResolveTime()
     {
         var container = new ServiceContainer();
         container.AddTime().WithRealTime().SetDefault();
         return container.BuildServiceProvider().Resolve<ITimeProvider>();
     }
+
+    /// <summary>
+    /// Builds the minimal single-claim principal (<c>k=v</c>) used by the scenarios that only need
+    /// a token to exist (expiry / audience / lifetime checks), where the specific claims are irrelevant.
+    /// </summary>
+    /// <returns>A claims principal carrying a single <c>k=v</c> claim.</returns>
+    protected static ClaimsPrincipal MinimalPrincipal() =>
+        new(new ClaimsIdentity(new[] { new Claim("k", "v") }, "JWT"));
 }

--- a/base/Identity/tests/Annium.Identity.Tokens.Jwt.Tests/ServiceContainerExtensionsTests.cs
+++ b/base/Identity/tests/Annium.Identity.Tokens.Jwt.Tests/ServiceContainerExtensionsTests.cs
@@ -1,0 +1,75 @@
+using System;
+using Annium.Core.DependencyInjection;
+using Annium.Testing;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Annium.Identity.Tokens.Jwt.Tests;
+
+/// <summary>
+/// Verifies that <see cref="ServiceContainerExtensions.AddJwtTokens{TContainer}"/> enforces
+/// fail-fast guards for required configuration: <c>SigningKey</c>, <c>Algorithm</c>, and <c>Issuer</c>
+/// must all be supplied or the method throws <see cref="InvalidOperationException"/> immediately.
+/// </summary>
+public class ServiceContainerExtensionsTests
+{
+    /// <summary>
+    /// When <c>SigningKey</c> is left unset, <see cref="ServiceContainerExtensions.AddJwtTokens{TContainer}"/>
+    /// must throw <see cref="InvalidOperationException"/> at registration time.
+    /// </summary>
+    [Fact]
+    public void AddJwtTokens_SigningKeyNull_Throws()
+    {
+        var container = new ServiceContainer();
+
+        Wrap.It(() =>
+                container.AddJwtTokens(o =>
+                {
+                    o.Algorithm = SecurityAlgorithms.RsaSha256;
+                    o.Issuer = "service";
+                    // SigningKey intentionally left null
+                })
+            )
+            .Throws<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// When <c>Algorithm</c> is left unset (empty string), <see cref="ServiceContainerExtensions.AddJwtTokens{TContainer}"/>
+    /// must throw <see cref="InvalidOperationException"/> at registration time.
+    /// </summary>
+    [Fact]
+    public void AddJwtTokens_AlgorithmEmpty_Throws()
+    {
+        var container = new ServiceContainer();
+
+        Wrap.It(() =>
+                container.AddJwtTokens(o =>
+                {
+                    o.SigningKey = new SymmetricSecurityKey(new byte[32]);
+                    o.Issuer = "service";
+                    // Algorithm intentionally left as default empty string
+                })
+            )
+            .Throws<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// When <c>Issuer</c> is left unset (empty string), <see cref="ServiceContainerExtensions.AddJwtTokens{TContainer}"/>
+    /// must throw <see cref="InvalidOperationException"/> at registration time.
+    /// </summary>
+    [Fact]
+    public void AddJwtTokens_IssuerEmpty_Throws()
+    {
+        var container = new ServiceContainer();
+
+        Wrap.It(() =>
+                container.AddJwtTokens(o =>
+                {
+                    o.SigningKey = new SymmetricSecurityKey(new byte[32]);
+                    o.Algorithm = SecurityAlgorithms.RsaSha256;
+                    // Issuer intentionally left as default empty string
+                })
+            )
+            .Throws<InvalidOperationException>();
+    }
+}

--- a/base/Identity/tests/Annium.Identity.Tokens.Tests/EcdsaTests.cs
+++ b/base/Identity/tests/Annium.Identity.Tokens.Tests/EcdsaTests.cs
@@ -26,11 +26,7 @@ public class EcdsaTests
         var key = ECDsa.Create().ImportPem(raw).GetKey();
 
         // assert
-        key.IsNotDefault();
-        key.KeyId.Is("DPTN:WDOT:XCT7:NHYZ:NSAE:GVQT:OQIX:TCZ6:E3GE:67EY:QA3D:5Q7E");
-        // unfortunately, for ECDsa this field is hardcoded to unknown now
-        key.PrivateKeyStatus.Is(PrivateKeyStatus.Unknown);
-        key.KeySize.Is(521);
+        AssertKeyProperties(key);
     }
 
     /// <summary>
@@ -47,8 +43,34 @@ public class EcdsaTests
         var key = ECDsa.Create().ImportPem(raw).GetKey();
 
         // assert
+        AssertKeyProperties(key);
+    }
+
+    /// <summary>
+    /// Two independently generated ECDSA keys must produce different key identifiers, confirming
+    /// that <c>GetKeyId</c> derives the id from the key material rather than a constant or counter.
+    /// The created <see cref="ECDsa"/> instances are intentionally not disposed (same rationale as
+    /// the JWT test fixtures).
+    /// </summary>
+    [Fact]
+    public void GetKeyId_DistinctKeys_ProduceDifferentIds()
+    {
+        var id1 = ECDsa.Create().GetKey().KeyId;
+        var id2 = ECDsa.Create().GetKey().KeyId;
+
+        id1.IsNotEqual(id2);
+    }
+
+    /// <summary>
+    /// Asserts the fixture key's identity properties: non-default, the pinned KeyId, the
+    /// runtime-reported private-key status (Unknown for ECDsa), and the secp521r1 key size.
+    /// </summary>
+    /// <param name="key">The imported ECDSA security key.</param>
+    private static void AssertKeyProperties(ECDsaSecurityKey key)
+    {
         key.IsNotDefault();
         key.KeyId.Is("DPTN:WDOT:XCT7:NHYZ:NSAE:GVQT:OQIX:TCZ6:E3GE:67EY:QA3D:5Q7E");
+        // unfortunately, for ECDsa this field is hardcoded to unknown now
         key.PrivateKeyStatus.Is(PrivateKeyStatus.Unknown);
         key.KeySize.Is(521);
     }

--- a/base/Identity/tests/Annium.Identity.Tokens.Tests/RsaTests.cs
+++ b/base/Identity/tests/Annium.Identity.Tokens.Tests/RsaTests.cs
@@ -26,10 +26,7 @@ public class RsaTests
         var key = RSA.Create().ImportPem(raw).GetKey();
 
         // assert
-        key.IsNotDefault();
-        key.KeyId.Is("3PRM:GCC2:G2M2:OTXW:AMG5:OD6L:B7AM:UPKV:7WKO:GEMW:D5S7:DZBZ");
-        key.PrivateKeyStatus.Is(PrivateKeyStatus.Exists);
-        key.KeySize.Is(2048);
+        AssertKeyProperties(key, PrivateKeyStatus.Exists);
     }
 
     /// <summary>
@@ -46,9 +43,35 @@ public class RsaTests
         var key = RSA.Create().ImportPem(raw).GetKey();
 
         // assert
+        AssertKeyProperties(key, PrivateKeyStatus.Unknown);
+    }
+
+    /// <summary>
+    /// Two independently generated RSA keys must produce different key identifiers, confirming
+    /// that <c>GetKeyId</c> derives the id from the key material rather than a constant or counter.
+    /// The created <see cref="RSA"/> instances are intentionally not disposed (same rationale as
+    /// the JWT test fixtures).
+    /// </summary>
+    [Fact]
+    public void GetKeyId_DistinctKeys_ProduceDifferentIds()
+    {
+        var id1 = RSA.Create().GetKey().KeyId;
+        var id2 = RSA.Create().GetKey().KeyId;
+
+        id1.IsNotEqual(id2);
+    }
+
+    /// <summary>
+    /// Asserts the fixture key's identity properties: non-default, the pinned KeyId, the given
+    /// private-key status, and the 2048-bit key size.
+    /// </summary>
+    /// <param name="key">The imported RSA security key.</param>
+    /// <param name="privateKeyStatus">Expected status (Exists for the private key, Unknown for the public).</param>
+    private static void AssertKeyProperties(RsaSecurityKey key, PrivateKeyStatus privateKeyStatus)
+    {
         key.IsNotDefault();
         key.KeyId.Is("3PRM:GCC2:G2M2:OTXW:AMG5:OD6L:B7AM:UPKV:7WKO:GEMW:D5S7:DZBZ");
-        key.PrivateKeyStatus.Is(PrivateKeyStatus.Unknown);
+        key.PrivateKeyStatus.Is(privateKeyStatus);
         key.KeySize.Is(2048);
     }
 }


### PR DESCRIPTION
- AddJwtTokens fail-fasts (InvalidOperationException) on missing SigningKey / empty Algorithm / Issuer instead of a later NRE
- JwtWriter omits the aud claim when no audience is configured (previously emitted aud="")
- remove a no-op test assertion; extract reader/writer/key-loading test helpers and shared status-message constants
- expand identity coverage 14 -> 34 tests (RSA override parity, registration guards, failure-status mapping, GetKeyId uniqueness)