### PR TITLE
fix(net-sockets): close CTS/socket leaks, harden teardown, expand tests

### DIFF
--- a/base/Net/src/Annium.Net.Sockets/ClientSocket.cs
+++ b/base/Net/src/Annium.Net.Sockets/ClientSocket.cs
@@ -61,7 +61,7 @@ public class ClientSocket : IClientSocket
     /// <summary>
     /// Connection monitor for health checking and reconnection logic.
     /// </summary>
-    private readonly ConnectionMonitorBase _connectionMonitor;
+    private readonly IConnectionMonitor _connectionMonitor;
 
     /// <summary>
     /// Timeout for connection attempts in milliseconds.
@@ -226,11 +226,19 @@ public class ClientSocket : IClientSocket
     }
 
     /// <summary>
-    /// Disposes the socket by triggering <see cref="Disconnect"/>.
+    /// Disposes the socket by triggering <see cref="Disconnect"/> and disposing the connection CTS.
     /// </summary>
     public void Dispose()
     {
         Disconnect();
+
+        // Disconnect() leaves _connectionCts pointing at a fresh, already-cancelled replacement
+        // (the "never points to a disposed instance" invariant). Dispose() is terminal: _status is
+        // Disconnected, so no Connect/Reconnect path will read the token again — dispose the
+        // replacement here to avoid leaking one CTS per socket lifetime.
+#pragma warning disable VSTHRD103
+        _connectionCts.Dispose();
+#pragma warning restore VSTHRD103
     }
 
     /// <summary>
@@ -259,12 +267,23 @@ public class ClientSocket : IClientSocket
         {
             try
             {
-                await Task.Delay(_reconnectDelay);
+                // observe the connection token so a Disconnect() during the backoff cancels the
+                // scheduled reconnect promptly. Read under _locker, where _connectionCts always
+                // points to the current (non-disposed) instance — disposal only targets the
+                // rotated-out old value.
+                CancellationToken ct;
+                lock (_locker)
+                    ct = _connectionCts.Token;
+                await Task.Delay(_reconnectDelay, ct);
                 this.Trace("trigger connect");
                 ConnectPrivate(config);
                 this.Trace("done");
             }
+            // OCE: the delay was cancelled by Disconnect(). ODE: _connectionCts was rotated and
+            // disposed out from under us between the token read and the delay registration. Both
+            // mean "teardown happened, abandon the scheduled reconnect".
             catch (OperationCanceledException) { }
+            catch (ObjectDisposedException) { }
             catch (Exception ex)
             {
                 this.Error("scheduled reconnect failed: {exception}", ex);
@@ -310,6 +329,10 @@ public class ClientSocket : IClientSocket
                 await task.ContinueWith(HandleConnected, config, CancellationToken.None);
             }
             catch (OperationCanceledException) { }
+            // ODE: a concurrent Disconnect() rotated and disposed cts before/while we read cts.Token
+            // — the same teardown race ReconnectPrivate handles; treat as expected cancellation
+            // rather than logging a spurious error.
+            catch (ObjectDisposedException) { }
             catch (Exception ex)
             {
                 this.Error("ConnectPrivate background connect failed: {exception}", ex);
@@ -331,6 +354,8 @@ public class ClientSocket : IClientSocket
         if (task.Exception is not null)
             this.Error(task.Exception);
 
+        // task.Result is non-blocking here: this runs as a ContinueWith continuation, so the
+        // antecedent connect task has already completed.
 #pragma warning disable VSTHRD002
         lock (_locker)
         {
@@ -350,6 +375,8 @@ public class ClientSocket : IClientSocket
 
         if (task.Result is not null)
         {
+            // state! is safe: it is always the non-null ConnectionConfig passed as the ContinueWith
+            // state argument in ConnectPrivate.
             var config = (ConnectionConfig)state!;
             this.Trace("failure: {exception}, init reconnect", task.Exception);
             ReconnectPrivate(config, new SocketCloseResult(SocketCloseStatus.Error, task.Result));
@@ -442,6 +469,8 @@ public class ClientSocket : IClientSocket
             SetStatus(Status.Connecting);
         }
 
+        // task.Result is non-blocking here: this runs as a ContinueWith continuation, so the
+        // antecedent IsClosed task has already completed.
 #pragma warning disable VSTHRD002
         ReconnectPrivate(Config, task.Result);
 #pragma warning restore VSTHRD002

--- a/base/Net/src/Annium.Net.Sockets/ClientSocketExtensions.cs
+++ b/base/Net/src/Annium.Net.Sockets/ClientSocketExtensions.cs
@@ -43,9 +43,9 @@ public static class ClientSocketExtensions
     /// <param name="socket">The client socket to monitor.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A task that completes when the socket connects.</returns>
-    public static Task WhenConnectedAsync(this IClientSocket socket, CancellationToken ct = default)
+    public static async Task WhenConnectedAsync(this IClientSocket socket, CancellationToken ct = default)
     {
-        var tcs = new TaskCompletionSource();
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         socket.Trace<string>("subscribe {tcs} to OnConnected", tcs.GetFullId());
 
@@ -53,12 +53,20 @@ public static class ClientSocketExtensions
         {
             socket.Trace<string>("set {tcs} to signaled state", tcs.GetFullId());
             tcs.TrySetResult();
-            socket.OnConnected -= HandleConnected;
         }
 
         socket.OnConnected += HandleConnected;
 
-        return tcs.Task.WaitAsync(ct);
+        // unsubscribe in finally so a cancelled wait does not leak the handler on the socket's
+        // OnConnected multicast list (the handler no longer self-unsubscribes).
+        try
+        {
+            await tcs.Task.WaitAsync(ct);
+        }
+        finally
+        {
+            socket.OnConnected -= HandleConnected;
+        }
     }
 
     /// <summary>

--- a/base/Net/src/Annium.Net.Sockets/ConnectionMonitorBase.cs
+++ b/base/Net/src/Annium.Net.Sockets/ConnectionMonitorBase.cs
@@ -5,9 +5,12 @@ using Annium.Logging;
 namespace Annium.Net.Sockets;
 
 /// <summary>
-/// Base class for connection monitors that detect when socket connections are lost.
+/// Base class for connection monitors that detect when socket connections are lost. Implements
+/// <see cref="IConnectionMonitor"/> and centralizes the start/stop idempotency invariant
+/// (<see cref="Interlocked"/>-guarded running flag); subclasses supply only
+/// <see cref="HandleStart"/> / <see cref="HandleStop"/>.
 /// </summary>
-public abstract class ConnectionMonitorBase : ILogSubject
+public abstract class ConnectionMonitorBase : IConnectionMonitor, ILogSubject
 {
     /// <summary>
     /// Gets the logger instance.
@@ -27,11 +30,10 @@ public abstract class ConnectionMonitorBase : ILogSubject
     private int _isRunning;
 
     /// <summary>
-    /// Returns the current running flag using a volatile read so background callers (e.g. timer
-    /// callbacks) observe the latest write made by <see cref="Start"/> / <see cref="Stop"/>.
+    /// Gets whether the monitor is currently running, using a volatile read so background callers
+    /// (e.g. timer callbacks) observe the latest write made by <see cref="Start"/> / <see cref="Stop"/>.
     /// </summary>
-    /// <returns>1 when the monitor is running, 0 otherwise.</returns>
-    protected int ReadIsRunning() => Volatile.Read(ref _isRunning);
+    protected bool IsRunning => Volatile.Read(ref _isRunning) == 1;
 
     /// <summary>
     /// Initializes a new instance of the ConnectionMonitorBase class.

--- a/base/Net/src/Annium.Net.Sockets/ConnectionMonitorOptions.cs
+++ b/base/Net/src/Annium.Net.Sockets/ConnectionMonitorOptions.cs
@@ -18,5 +18,5 @@ public record ConnectionMonitorOptions
     /// <summary>
     /// Gets or sets the maximum delay allowed for ping responses in milliseconds (default: 300000ms).
     /// </summary>
-    public long MaxPingDelay { get; init; } = 300_000;
+    public int MaxPingDelay { get; init; } = 300_000;
 }

--- a/base/Net/src/Annium.Net.Sockets/IConnectionMonitor.cs
+++ b/base/Net/src/Annium.Net.Sockets/IConnectionMonitor.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Annium.Net.Sockets;
+
+/// <summary>
+/// Monitors a socket connection and raises <see cref="OnConnectionLost"/> when the connection is
+/// detected as lost. The default implementation (<see cref="ConnectionMonitorBase"/>) centralizes the
+/// start/stop idempotency invariant; custom monitors deriving from it inherit that guarantee.
+/// </summary>
+public interface IConnectionMonitor
+{
+    /// <summary>
+    /// Event raised when the connection is detected as lost.
+    /// </summary>
+    event Action OnConnectionLost;
+
+    /// <summary>
+    /// Starts the connection monitor.
+    /// </summary>
+    void Start();
+
+    /// <summary>
+    /// Stops the connection monitor.
+    /// </summary>
+    void Stop();
+}

--- a/base/Net/src/Annium.Net.Sockets/IConnectionMonitorFactory.cs
+++ b/base/Net/src/Annium.Net.Sockets/IConnectionMonitorFactory.cs
@@ -11,5 +11,5 @@ public interface IConnectionMonitorFactory
     /// <param name="socket">The socket to monitor.</param>
     /// <param name="options">Configuration options for the monitor.</param>
     /// <returns>A connection monitor instance.</returns>
-    ConnectionMonitorBase Create(ISendingReceivingSocket socket, ConnectionMonitorOptions options);
+    IConnectionMonitor Create(ISendingReceivingSocket socket, ConnectionMonitorOptions options);
 }

--- a/base/Net/src/Annium.Net.Sockets/IServerSocket.cs
+++ b/base/Net/src/Annium.Net.Sockets/IServerSocket.cs
@@ -9,6 +9,14 @@ namespace Annium.Net.Sockets;
 public interface IServerSocket : ISendingReceivingSocket, IDisposable, ILogSubject
 {
     /// <summary>
+    /// Indicates whether the socket is currently connected to the client. Goes false
+    /// synchronously when <see cref="Disconnect"/> begins (or when the connection is closed);
+    /// remains false through the background teardown and the eventual <see cref="OnDisconnected"/>
+    /// firing — handlers observe a disconnected socket.
+    /// </summary>
+    bool IsConnected { get; }
+
+    /// <summary>
     /// Event raised when the socket is disconnected from the client.
     /// </summary>
     event Action<SocketCloseStatus> OnDisconnected;

--- a/base/Net/src/Annium.Net.Sockets/Internal/ClientManagedSocket.cs
+++ b/base/Net/src/Annium.Net.Sockets/Internal/ClientManagedSocket.cs
@@ -70,6 +70,14 @@ internal class ClientManagedSocket : IClientManagedSocket, ILogSubject
 
         TeardownUnderLock();
 
+        // TeardownUnderLock only disposes _listenCts when a live connection was torn down; on the
+        // never-connected (or double-dispose) path it returns early. Dispose _listenCts here so the
+        // constructor-created instance is always released. CTS.Dispose() is idempotent, so the
+        // connected path (already disposed under the lock) is a safe no-op.
+#pragma warning disable VSTHRD103
+        _listenCts.Dispose();
+#pragma warning restore VSTHRD103
+
         this.Trace("done");
     }
 
@@ -94,10 +102,11 @@ internal class ClientManagedSocket : IClientManagedSocket, ILogSubject
 
         Stream? stream = null;
         IManagedSocket? socket = null;
+        Socket? nativeSocket = null;
         try
         {
             this.Trace("create native socket");
-            var nativeSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            nativeSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 
             this.Trace("connect native socket to {endpoint}", endpoint);
             await nativeSocket.ConnectAsync(endpoint, ct);
@@ -147,13 +156,25 @@ internal class ClientManagedSocket : IClientManagedSocket, ILogSubject
                     cn.Dispose();
 #pragma warning restore VSTHRD103
 
-                    return null;
+                    // return a non-null exception, not null: null is the success sentinel, which would
+                    // make the caller fire OnConnected and subscribe the stale pre-connect IsClosed task
+                    // even though the connection was just torn down. A non-null result routes the caller
+                    // through its failed-connect path instead.
+                    return new OperationCanceledException(ct);
                 }
 
                 this.Trace("save connection");
                 _cn = cn;
 
                 this.Trace("create listen cts");
+                // dispose the previous CTS before replacing it: the constructor-created instance
+                // is never used for a listen task and would otherwise leak on first connect;
+                // CancellationTokenSource.Dispose() is idempotent, so a reconnect (where teardown
+                // already disposed it) is safe.
+                // VSTHRD103: CancellationTokenSource.Dispose() is synchronous (no DisposeAsync).
+#pragma warning disable VSTHRD103
+                _listenCts.Dispose();
+#pragma warning restore VSTHRD103
                 _listenCts = new CancellationTokenSource();
 
                 this.Trace("create listen task");
@@ -176,6 +197,14 @@ internal class ClientManagedSocket : IClientManagedSocket, ILogSubject
             this.Error("failed: {e}", e);
 
             Cleanup(stream, socket);
+
+            // if no Stream wrapped the native socket yet (e.g. nativeSocket.ConnectAsync threw on
+            // timeout/refusal), the NetworkStream never took ownership (ownsSocket: true) — dispose
+            // the native socket here to avoid leaking the OS handle on every failed connect.
+#pragma warning disable VSTHRD103
+            if (stream is null)
+                nativeSocket?.Dispose();
+#pragma warning restore VSTHRD103
 
             this.Trace("done (not connected)");
 

--- a/base/Net/src/Annium.Net.Sockets/Internal/DefaultConnectionMonitor.cs
+++ b/base/Net/src/Annium.Net.Sockets/Internal/DefaultConnectionMonitor.cs
@@ -96,7 +96,7 @@ internal class DefaultConnectionMonitor : ConnectionMonitorBase
         this.Trace("send ping");
         await _socket.SendAsync(ProtocolFrames.Ping);
 
-        if (ReadIsRunning() == 0)
+        if (!IsRunning)
         {
             this.Trace("skip - already stopped");
             return;
@@ -125,7 +125,7 @@ internal class DefaultConnectionMonitor : ConnectionMonitorBase
         if (!data.Span.SequenceEqual(ProtocolFrames.Ping.Span))
             return;
 
-        if (ReadIsRunning() == 0)
+        if (!IsRunning)
         {
             this.Trace("skip - already stopped");
             return;

--- a/base/Net/src/Annium.Net.Sockets/Internal/DefaultConnectionMonitorFactory.cs
+++ b/base/Net/src/Annium.Net.Sockets/Internal/DefaultConnectionMonitorFactory.cs
@@ -27,7 +27,7 @@ internal class DefaultConnectionMonitorFactory : IConnectionMonitorFactory
     /// <param name="socket">The socket to monitor.</param>
     /// <param name="options">Configuration options for the monitor.</param>
     /// <returns>A new default connection monitor instance.</returns>
-    public ConnectionMonitorBase Create(ISendingReceivingSocket socket, ConnectionMonitorOptions options)
+    public IConnectionMonitor Create(ISendingReceivingSocket socket, ConnectionMonitorOptions options)
     {
         return new DefaultConnectionMonitor(socket, options, _logger);
     }

--- a/base/Net/src/Annium.Net.Sockets/Internal/SocketEventHelpers.cs
+++ b/base/Net/src/Annium.Net.Sockets/Internal/SocketEventHelpers.cs
@@ -20,27 +20,34 @@ internal static class SocketEventHelpers
     /// <param name="log">Log subject for tracing.</param>
     /// <param name="ct">Cancellation token applied to the wait.</param>
     /// <returns>The disconnect status reported by the first event invocation.</returns>
-    public static Task<SocketCloseStatus> WaitForDisconnectAsync(
+    public static async Task<SocketCloseStatus> WaitForDisconnectAsync(
         Action<Action<SocketCloseStatus>> subscribe,
         Action<Action<SocketCloseStatus>> unsubscribe,
         ILogSubject log,
         CancellationToken ct
     )
     {
-        var tcs = new TaskCompletionSource<SocketCloseStatus>();
+        var tcs = new TaskCompletionSource<SocketCloseStatus>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         log.Trace<string>("subscribe {tcs} to OnDisconnected", tcs.GetFullId());
 
-        Action<SocketCloseStatus> handler = null!;
-        handler = status =>
+        Action<SocketCloseStatus> handler = status =>
         {
             log.Trace<string>("set {tcs} to signaled state", tcs.GetFullId());
             tcs.TrySetResult(status);
-            unsubscribe(handler);
         };
 
         subscribe(handler);
 
-        return tcs.Task.WaitAsync(ct);
+        // unsubscribe in finally so a cancelled wait does not leak the handler (the handler no
+        // longer self-unsubscribes).
+        try
+        {
+            return await tcs.Task.WaitAsync(ct);
+        }
+        finally
+        {
+            unsubscribe(handler);
+        }
     }
 }

--- a/base/Net/src/Annium.Net.Sockets/ServerSocket.cs
+++ b/base/Net/src/Annium.Net.Sockets/ServerSocket.cs
@@ -34,6 +34,20 @@ public class ServerSocket : IServerSocket
     public event Action<Exception> OnError = delegate { };
 
     /// <summary>
+    /// Indicates whether the socket is currently connected to the client. Goes false synchronously
+    /// (under <c>_locker</c>) when <see cref="Disconnect"/> begins or the connection is closed, so
+    /// handlers firing later from the background teardown observe the disconnected state.
+    /// </summary>
+    public bool IsConnected
+    {
+        get
+        {
+            lock (_locker)
+                return _status == Status.Connected;
+        }
+    }
+
+    /// <summary>
     /// Thread synchronization lock for socket operations.
     /// </summary>
     private readonly Lock _locker = new();
@@ -46,7 +60,7 @@ public class ServerSocket : IServerSocket
     /// <summary>
     /// Connection monitor for health checking and connection management.
     /// </summary>
-    private readonly ConnectionMonitorBase _connectionMonitor;
+    private readonly IConnectionMonitor _connectionMonitor;
 
     /// <summary>
     /// Current connection status of the socket.
@@ -172,17 +186,23 @@ public class ServerSocket : IServerSocket
     }
 
     /// <summary>
-    /// Disposes the socket with **forced-close** semantics: synchronously disposes the
-    /// underlying managed socket so the stream is closed deterministically rather than via
-    /// the GC finalizer. Does NOT trigger a graceful disconnect — callers wanting graceful
-    /// close should call <see cref="Disconnect"/> first and wait for <see cref="OnDisconnected"/>
-    /// to fire (or use the <c>WhenDisconnectedAsync</c> extension) before invoking
-    /// <see cref="Dispose"/>. Mixing graceful and forced close in a single <see cref="Dispose"/>
-    /// body would race the synchronous teardown against the fire-and-forget
+    /// Disposes the socket with **forced-close** semantics: stops the connection monitor and
+    /// synchronously disposes the underlying managed socket so the stream is closed
+    /// deterministically rather than via the GC finalizer. Does NOT trigger a graceful disconnect
+    /// — callers wanting graceful close should call <see cref="Disconnect"/> first and wait for
+    /// <see cref="OnDisconnected"/> to fire (or use the <c>WhenDisconnectedAsync</c> extension)
+    /// before invoking <see cref="Dispose"/>. Mixing graceful and forced close in a single
+    /// <see cref="Dispose"/> body would race the synchronous teardown against the fire-and-forget
     /// <see cref="Disconnect"/> background task.
     /// </summary>
     public void Dispose()
     {
+        // Stop the monitor first: IConnectionMonitor.Stop() is synchronous and idempotent and
+        // only halts the monitor's ping timer (it never touches the socket), so it does not
+        // introduce the graceful-vs-forced race described above. Without it, disposing without a
+        // prior Disconnect() leaks the monitor timer, which keeps pinging the dead socket.
+        _connectionMonitor.Stop();
+
         _socket.Dispose();
     }
 

--- a/base/Net/tests/Annium.Net.Sockets.Tests/ClientServerSocketTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/ClientServerSocketTests.cs
@@ -504,6 +504,9 @@ public class ClientServerSocketTests : TestBase
         var clientTcs = new TaskCompletionSource();
         var connectionIndex = 0;
         var connectionsCount = 3;
+        // seeded so the per-connection break points are deterministic and reproducible across runs
+        // (handlers run serially across reconnects, so a single shared instance is safe).
+        var breakRandom = new Random(12345);
 
         this.Trace("run server");
         await using var server = _runServer(
@@ -511,12 +514,15 @@ public class ClientServerSocketTests : TestBase
             {
                 this.Trace("start sending messages");
 
-                connectionIndex++;
+                // Interlocked + a local snapshot: the handler runs per accepted connection on a
+                // pool thread, so a non-atomic connectionIndex++ would be a data race if a reconnect
+                // ever overlapped the prior handler.
+                var idx = Interlocked.Increment(ref connectionIndex);
 
-                var complete = connectionIndex == connectionsCount;
+                var complete = idx == connectionsCount;
 
                 var i = 0;
-                var breakAtMessage = complete ? int.MaxValue : new Random().Next(1, messages.Count - 1);
+                var breakAtMessage = complete ? int.MaxValue : breakRandom.Next(1, messages.Count - 1);
                 foreach (var message in messages)
                 {
                     i++;
@@ -526,7 +532,7 @@ public class ClientServerSocketTests : TestBase
                     {
                         this.Trace(
                             "disconnect, connection {connectionIndex}/{connectionsCount} at message#{num}",
-                            connectionIndex,
+                            idx,
                             connectionsCount,
                             i
                         );
@@ -600,8 +606,8 @@ public class ClientServerSocketTests : TestBase
         Configure(streamType, serverOptions);
 
         // arrange
-        this.Trace("generate messages");
-        var disconnectCounter = 0;
+        this.Trace("prepare disconnect signal");
+        var disconnectedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         this.Trace("run server");
         await using var server = _runServer(
@@ -619,18 +625,20 @@ public class ClientServerSocketTests : TestBase
         ClientSocket.OnDisconnected += _ =>
         {
             this.Trace("disconnected");
-            Interlocked.Increment(ref disconnectCounter);
+            // first loss wins; with ReconnectDelay=1 the client may cycle, so we only assert the
+            // first OnDisconnected — not an exact count.
+            disconnectedTcs.TrySetResult();
         };
 
         this.Trace("connect");
         await ConnectAsync(server);
 
-        this.Trace("wait");
-        await Task.Delay(700, TestContext.Current.CancellationToken);
-
-        // assert
-        this.Trace("assert disconnected");
-        disconnectCounter.Is(1);
+        // assert — the client connection monitor (PingInterval=100/MaxPingDelay=500) gets no pong
+        // from the server (whose monitor is effectively disabled at 60s/300s) and fires
+        // OnDisconnected. Awaiting the signal (bounded) replaces a fixed Task.Delay(700), so the
+        // test no longer races a ~500ms timeout against a fixed window — robust under CI load.
+        this.Trace("assert disconnected within timeout");
+        await disconnectedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         this.Trace("done");
     }
@@ -716,7 +724,7 @@ public class ClientServerSocketTests : TestBase
     {
         this.Trace("start");
 
-        _clientSocket?.Disconnect();
+        _clientSocket?.Dispose();
 
         this.Trace("done");
 

--- a/base/Net/tests/Annium.Net.Sockets.Tests/ClientSocketDisposeTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/ClientSocketDisposeTests.cs
@@ -1,0 +1,40 @@
+using Annium.Logging;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Net.Sockets.Tests;
+
+/// <summary>
+/// Tests that <see cref="ClientSocket.Dispose"/> is safe without a prior Connect and idempotent.
+/// </summary>
+public class ClientSocketDisposeTests
+{
+    /// <summary>
+    /// Calling Dispose() without ever calling Connect() must not throw and leaves the socket
+    /// disconnected. Verifies that the constructor-created CancellationTokenSource is disposed cleanly
+    /// (if Dispose threw, the test would fail; the assertion confirms the disposed socket is disconnected).
+    /// </summary>
+    [Fact]
+    public void Dispose_WithoutConnect_DoesNotThrowAndIsDisconnected()
+    {
+        var socket = new ClientSocket(ClientSocketOptions.Default, VoidLogger.Instance);
+
+        socket.Dispose();
+
+        socket.IsConnected.IsFalse();
+    }
+
+    /// <summary>
+    /// Calling Dispose() a second time on the same socket must not throw and stays disconnected.
+    /// </summary>
+    [Fact]
+    public void Dispose_CalledTwice_DoesNotThrowAndIsDisconnected()
+    {
+        var socket = new ClientSocket(ClientSocketOptions.Default, VoidLogger.Instance);
+
+        socket.Dispose();
+        socket.Dispose();
+
+        socket.IsConnected.IsFalse();
+    }
+}

--- a/base/Net/tests/Annium.Net.Sockets.Tests/ClientSocketExtensionsTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/ClientSocketExtensionsTests.cs
@@ -1,0 +1,422 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using Annium.Logging;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Net.Sockets.Tests;
+
+/// <summary>
+/// Tests for <see cref="ClientSocketExtensions"/>.
+/// </summary>
+public class ClientSocketExtensionsTests
+{
+    // -------------------------------------------------------------------------
+    // Connect(Uri) — TG5
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Connecting via a loopback URI passes an <see cref="IPEndPoint"/> at the correct port
+    /// to the underlying <see cref="IClientSocket.Connect(IPEndPoint, SslClientAuthenticationOptions?)"/>.
+    /// </summary>
+    [Fact]
+    public void Connect_LoopbackUri_PassesCorrectPort()
+    {
+        const int port = 19876;
+        var uri = new Uri($"http://127.0.0.1:{port}");
+        var fake = new RecordingClientSocket();
+
+        fake.Connect(uri);
+
+        fake.ConnectedEndpoints.Has(1);
+        fake.ConnectedEndpoints.At(0).Port.Is(port);
+    }
+
+    /// <summary>
+    /// Connecting via a loopback URI resolves an address and forwards it to the socket.
+    /// </summary>
+    [Fact]
+    public void Connect_LoopbackUri_ResolvesAddress()
+    {
+        var uri = new Uri("http://127.0.0.1:11111");
+        var fake = new RecordingClientSocket();
+
+        fake.Connect(uri);
+
+        fake.ConnectedEndpoints.Has(1);
+        fake.ConnectedEndpoints.At(0).Address.Is(IPAddress.Loopback);
+    }
+
+    // -------------------------------------------------------------------------
+    // WhenConnectedAsync cancellation — TG7
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// When the cancellation token is cancelled before OnConnected fires,
+    /// <see cref="ClientSocketExtensions.WhenConnectedAsync"/> throws
+    /// <see cref="OperationCanceledException"/> and the handler is unsubscribed.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task WhenConnectedAsync_TokenCancelledBeforeConnected_ThrowsAndUnsubscribes()
+    {
+        var fake = new FakeClientSocket();
+        using var cts = new CancellationTokenSource();
+
+        var waitTask = fake.WhenConnectedAsync(cts.Token);
+
+        // Cancel the token before the OnConnected event is ever raised.
+        await cts.CancelAsync();
+
+        // The task must fault with OperationCanceledException. waitTask was started before the
+        // cancel (to exercise cancel-after-subscribe), so it is awaited directly here.
+        var threw = false;
+        try
+        {
+            await waitTask;
+        }
+        catch (OperationCanceledException)
+        {
+            threw = true;
+        }
+
+        threw.IsTrue();
+
+        // After cancellation the OnConnected handler should be unsubscribed so
+        // raising the event no longer reaches the (now-abandoned) TCS.
+        fake.HasConnectedSubscribers.IsFalse();
+    }
+
+    /// <summary>
+    /// When the cancellation token is already cancelled at call time,
+    /// <see cref="ClientSocketExtensions.WhenConnectedAsync"/> throws immediately
+    /// without leaking the subscription.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task WhenConnectedAsync_PreCancelledToken_ThrowsImmediatelyAndUnsubscribes()
+    {
+        var fake = new FakeClientSocket();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Wrap.It(async () => await fake.WhenConnectedAsync(cts.Token)).ThrowsAsync<OperationCanceledException>();
+        fake.HasConnectedSubscribers.IsFalse();
+    }
+
+    /// <summary>
+    /// After cancellation, raising OnConnected on the fake has no effect (subscription
+    /// was cleaned up). This verifies the finally-unsubscribe path does not leave a dangling
+    /// handler on the socket's multicast list.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task WhenConnectedAsync_AfterCancellation_RaisingConnectedHasNoEffect()
+    {
+        var fake = new FakeClientSocket();
+        using var cts = new CancellationTokenSource();
+
+        var waitTask = fake.WhenConnectedAsync(cts.Token);
+        await cts.CancelAsync();
+
+        try
+        {
+            await waitTask;
+        }
+        catch (OperationCanceledException)
+        {
+            // expected
+        }
+
+        // Raise connected — must not throw and the subscriber count stays at zero.
+        fake.RaiseConnected();
+        fake.HasConnectedSubscribers.IsFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // WhenDisconnectedAsync cancellation — TG11
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// When the cancellation token is cancelled before OnDisconnected fires,
+    /// <see cref="ClientSocketExtensions.WhenDisconnectedAsync"/> throws
+    /// <see cref="OperationCanceledException"/> and the handler is unsubscribed.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task WhenDisconnectedAsync_TokenCancelledBeforeDisconnected_ThrowsAndUnsubscribes()
+    {
+        var fake = new FakeClientSocketWithDisconnect();
+        using var cts = new CancellationTokenSource();
+
+        var waitTask = fake.WhenDisconnectedAsync(cts.Token);
+
+        // Cancel the token before OnDisconnected is ever raised.
+        await cts.CancelAsync();
+
+        // waitTask was started before the cancel (exercises cancel-after-subscribe),
+        // so it is awaited directly here — manual try/catch to avoid VSTHRD003.
+        var threw = false;
+        try
+        {
+            await waitTask;
+        }
+        catch (OperationCanceledException)
+        {
+            threw = true;
+        }
+
+        threw.IsTrue();
+
+        // After cancellation the OnDisconnected handler should be unsubscribed.
+        fake.HasDisconnectedSubscribers.IsFalse();
+    }
+
+    /// <summary>
+    /// When the cancellation token is already cancelled at call time,
+    /// <see cref="ClientSocketExtensions.WhenDisconnectedAsync"/> throws immediately
+    /// without leaking the subscription.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task WhenDisconnectedAsync_PreCancelledToken_ThrowsImmediatelyAndUnsubscribes()
+    {
+        var fake = new FakeClientSocketWithDisconnect();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Wrap.It(async () => await fake.WhenDisconnectedAsync(cts.Token))
+            .ThrowsAsync<OperationCanceledException>();
+        fake.HasDisconnectedSubscribers.IsFalse();
+    }
+
+    /// <summary>
+    /// After cancellation, raising OnDisconnected on the fake has no effect — the subscription
+    /// was cleaned up and no dangling handler remains.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task WhenDisconnectedAsync_AfterCancellation_RaisingDisconnectedHasNoEffect()
+    {
+        var fake = new FakeClientSocketWithDisconnect();
+        using var cts = new CancellationTokenSource();
+
+        var waitTask = fake.WhenDisconnectedAsync(cts.Token);
+        await cts.CancelAsync();
+
+        try
+        {
+            await waitTask;
+        }
+        catch (OperationCanceledException)
+        {
+            // expected
+        }
+
+        // Raise disconnected — must not throw and the subscriber count stays at zero.
+        fake.RaiseDisconnected(SocketCloseStatus.ClosedLocal);
+        fake.HasDisconnectedSubscribers.IsFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Fakes
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Minimal <see cref="IClientSocket"/> fake that records endpoints passed to
+    /// <see cref="Connect(IPEndPoint, SslClientAuthenticationOptions?)"/>.
+    /// </summary>
+    private sealed class RecordingClientSocket : IClientSocket
+    {
+        /// <summary>Gets the logger used by this fake.</summary>
+        public ILogger Logger { get; } = VoidLogger.Instance;
+
+        /// <summary>Always false — this fake is not connected.</summary>
+        public bool IsConnected => false;
+
+        public event Action? OnConnected
+        {
+            add { }
+            remove { }
+        }
+
+        public event Action<SocketCloseStatus>? OnDisconnected
+        {
+            add { }
+            remove { }
+        }
+
+        public event Action<Exception>? OnError
+        {
+            add { }
+            remove { }
+        }
+
+        public event Action<ReadOnlyMemory<byte>>? OnReceived
+        {
+            add { }
+            remove { }
+        }
+
+        /// <summary>All endpoints passed to <c>Connect</c>.</summary>
+        public List<IPEndPoint> ConnectedEndpoints { get; } = [];
+
+        /// <summary>Records <paramref name="endpoint"/> so tests can assert the forwarded address and port.</summary>
+        /// <param name="endpoint">The remote endpoint passed to the extension method.</param>
+        /// <param name="authOptions">Optional SSL authentication options (ignored by this fake).</param>
+        public void Connect(IPEndPoint endpoint, SslClientAuthenticationOptions? authOptions = null) =>
+            ConnectedEndpoints.Add(endpoint);
+
+        /// <summary>No-op — this fake does not implement disconnect.</summary>
+        public void Disconnect() { }
+
+        /// <summary>Not implemented — this fake only exercises the <c>Connect</c> path.</summary>
+        /// <param name="data">The data to send.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>A <see cref="ValueTask{SocketSendStatus}"/> representing the pending send.</returns>
+        public ValueTask<SocketSendStatus> SendAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default) =>
+            ValueTask.FromResult(SocketSendStatus.Ok);
+
+        /// <summary>Disposes the fake socket (no-op).</summary>
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IClientSocket"/> fake with a raisable <see cref="OnConnected"/> event
+    /// and a subscriber-count helper for TG7.
+    /// </summary>
+    private sealed class FakeClientSocket : IClientSocket
+    {
+        /// <summary>Gets the logger used by this fake.</summary>
+        public ILogger Logger { get; } = VoidLogger.Instance;
+
+        /// <summary>Always false — this fake is never actually connected.</summary>
+        public bool IsConnected => false;
+
+        private event Action? _onConnected;
+
+        /// <summary>Event raised when the socket connects successfully.</summary>
+        public event Action OnConnected
+        {
+            add => _onConnected += value;
+            remove => _onConnected -= value;
+        }
+
+        public event Action<SocketCloseStatus>? OnDisconnected
+        {
+            add { }
+            remove { }
+        }
+
+        public event Action<Exception>? OnError
+        {
+            add { }
+            remove { }
+        }
+
+        public event Action<ReadOnlyMemory<byte>>? OnReceived
+        {
+            add { }
+            remove { }
+        }
+
+        /// <summary>
+        /// <see langword="true"/> when at least one handler is subscribed to <see cref="OnConnected"/>.
+        /// </summary>
+        public bool HasConnectedSubscribers => _onConnected is not null;
+
+        /// <summary>Raises <see cref="OnConnected"/>.</summary>
+        public void RaiseConnected() => _onConnected?.Invoke();
+
+        /// <summary>Not implemented — this fake only exercises the <c>OnConnected</c> subscription path.</summary>
+        /// <param name="endpoint">The remote endpoint to connect to.</param>
+        /// <param name="authOptions">Optional SSL authentication options.</param>
+        public void Connect(IPEndPoint endpoint, SslClientAuthenticationOptions? authOptions = null) =>
+            throw new NotImplementedException();
+
+        /// <summary>Not implemented — this fake only exercises the <c>OnConnected</c> subscription path.</summary>
+        public void Disconnect() => throw new NotImplementedException();
+
+        /// <summary>Not implemented — this fake only exercises the <c>OnConnected</c> subscription path.</summary>
+        /// <param name="data">The data to send.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>A <see cref="ValueTask{SocketSendStatus}"/> representing the pending send.</returns>
+        public ValueTask<SocketSendStatus> SendAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        /// <summary>Disposes the fake socket (no-op).</summary>
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IClientSocket"/> fake with a raisable <see cref="OnDisconnected"/> event
+    /// and a subscriber-count helper for TG11.
+    /// </summary>
+    private sealed class FakeClientSocketWithDisconnect : IClientSocket
+    {
+        /// <summary>Gets the logger used by this fake.</summary>
+        public ILogger Logger { get; } = VoidLogger.Instance;
+
+        /// <summary>Always false — this fake is never actually connected.</summary>
+        public bool IsConnected => false;
+
+        public event Action OnConnected
+        {
+            add { }
+            remove { }
+        }
+
+        private event Action<SocketCloseStatus>? _onDisconnected;
+
+        /// <summary>Event raised when the socket disconnects, carrying the close status.</summary>
+        public event Action<SocketCloseStatus> OnDisconnected
+        {
+            add => _onDisconnected += value;
+            remove => _onDisconnected -= value;
+        }
+
+        public event Action<Exception>? OnError
+        {
+            add { }
+            remove { }
+        }
+
+        public event Action<ReadOnlyMemory<byte>>? OnReceived
+        {
+            add { }
+            remove { }
+        }
+
+        /// <summary>
+        /// <see langword="true"/> when at least one handler is subscribed to <see cref="OnDisconnected"/>.
+        /// </summary>
+        public bool HasDisconnectedSubscribers => _onDisconnected is not null;
+
+        /// <summary>Raises <see cref="OnDisconnected"/> with the given status.</summary>
+        /// <param name="status">The close status to deliver to subscribers.</param>
+        public void RaiseDisconnected(SocketCloseStatus status) => _onDisconnected?.Invoke(status);
+
+        /// <summary>Not implemented — this fake only exercises the <c>OnDisconnected</c> subscription path.</summary>
+        /// <param name="endpoint">The remote endpoint to connect to.</param>
+        /// <param name="authOptions">Optional SSL authentication options.</param>
+        public void Connect(IPEndPoint endpoint, SslClientAuthenticationOptions? authOptions = null) =>
+            throw new NotImplementedException();
+
+        /// <summary>Not implemented — this fake only exercises the <c>OnDisconnected</c> subscription path.</summary>
+        public void Disconnect() => throw new NotImplementedException();
+
+        /// <summary>Not implemented — this fake only exercises the <c>OnDisconnected</c> subscription path.</summary>
+        /// <param name="data">The data to send.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>A <see cref="ValueTask{SocketSendStatus}"/> representing the pending send.</returns>
+        public ValueTask<SocketSendStatus> SendAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        /// <summary>Disposes the fake socket (no-op).</summary>
+        public void Dispose() { }
+    }
+}

--- a/base/Net/tests/Annium.Net.Sockets.Tests/ConnectionMonitorBaseTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/ConnectionMonitorBaseTests.cs
@@ -1,0 +1,110 @@
+using Annium.Logging;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Net.Sockets.Tests;
+
+/// <summary>
+/// Tests for the Start/Stop idempotency contract of <see cref="ConnectionMonitorBase"/>.
+/// </summary>
+public class ConnectionMonitorBaseTests
+{
+    /// <summary>
+    /// Calling Start() twice invokes HandleStart exactly once.
+    /// </summary>
+    [Fact]
+    public void Start_CalledTwice_HandleStartInvokedOnce()
+    {
+        var monitor = new CountingConnectionMonitor(VoidLogger.Instance);
+
+        monitor.Start();
+        monitor.Start();
+
+        monitor.StartCount.Is(1);
+    }
+
+    /// <summary>
+    /// Calling Stop() twice (after one Start) invokes HandleStop exactly once.
+    /// </summary>
+    [Fact]
+    public void Stop_CalledTwiceAfterStart_HandleStopInvokedOnce()
+    {
+        var monitor = new CountingConnectionMonitor(VoidLogger.Instance);
+
+        monitor.Start();
+        monitor.Stop();
+        monitor.Stop();
+
+        monitor.StopCount.Is(1);
+    }
+
+    /// <summary>
+    /// Calling Stop() on a fresh never-started monitor does not invoke HandleStop.
+    /// </summary>
+    [Fact]
+    public void Stop_CalledWithoutStart_HandleStopNotInvoked()
+    {
+        var monitor = new CountingConnectionMonitor(VoidLogger.Instance);
+
+        monitor.Stop();
+
+        monitor.StopCount.Is(0);
+    }
+
+    /// <summary>
+    /// Start → Stop → Start sequence calls each handler once per cycle.
+    /// </summary>
+    [Fact]
+    public void StartStop_Cycle_EachHandlerCalledOncePerCycle()
+    {
+        var monitor = new CountingConnectionMonitor(VoidLogger.Instance);
+
+        monitor.Start();
+        monitor.Stop();
+        monitor.Start();
+        monitor.Stop();
+
+        monitor.StartCount.Is(2);
+        monitor.StopCount.Is(2);
+    }
+
+    /// <summary>
+    /// IsRunning is true between Start and Stop.
+    /// </summary>
+    [Fact]
+    public void IsRunning_TrueAfterStartFalseAfterStop()
+    {
+        var monitor = new CountingConnectionMonitor(VoidLogger.Instance);
+
+        monitor.IsRunningPublic.IsFalse();
+
+        monitor.Start();
+        monitor.IsRunningPublic.IsTrue();
+
+        monitor.Stop();
+        monitor.IsRunningPublic.IsFalse();
+    }
+
+    /// <summary>
+    /// Concrete <see cref="ConnectionMonitorBase"/> subclass that counts how many times
+    /// <see cref="HandleStart"/> and <see cref="HandleStop"/> are invoked and exposes
+    /// the protected <c>IsRunning</c> property for assertion.
+    /// </summary>
+    private sealed class CountingConnectionMonitor(ILogger logger) : ConnectionMonitorBase(logger)
+    {
+        /// <summary>Number of times <see cref="HandleStart"/> was called.</summary>
+        public int StartCount { get; private set; }
+
+        /// <summary>Number of times <see cref="HandleStop"/> was called.</summary>
+        public int StopCount { get; private set; }
+
+        /// <summary>Exposes the protected <c>IsRunning</c> property for tests.</summary>
+        public bool IsRunningPublic => IsRunning;
+
+        /// <summary>Increments <c>StartCount</c>; used to assert that the base class invokes the hook exactly once per start cycle regardless of how many times <c>Start()</c> is called.</summary>
+        protected override void HandleStart() => StartCount++;
+
+        /// <summary>Increments <c>StopCount</c>; used to assert that the base class invokes the hook exactly once per stop cycle regardless of how many times <c>Stop()</c> is called.</summary>
+        protected override void HandleStop() => StopCount++;
+    }
+}

--- a/base/Net/tests/Annium.Net.Sockets.Tests/Internal/ClientServerManagedSocketTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/Internal/ClientServerManagedSocketTests.cs
@@ -377,7 +377,7 @@ public class ClientServerManagedSocketTests : TestBase
         await using var server = _runServer(async (serverSocket, _) => await serverSocket.IsClosed);
 
         this.Trace("connect");
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         await ConnectAsync(server, cts.Token);
 
         this.Trace("disconnect");

--- a/base/Net/tests/Annium.Net.Sockets.Tests/Internal/HelperClassifySendExceptionTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/Internal/HelperClassifySendExceptionTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Annium.Logging;
+using Annium.Net.Sockets.Internal;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Net.Sockets.Tests.Internal;
+
+/// <summary>
+/// Tests for <see cref="Helper.ClassifySendException"/> covering each exception branch in the
+/// classifier switch expression.
+/// </summary>
+public class HelperClassifySendExceptionTests
+{
+    /// <summary>
+    /// A plain subject that implements <see cref="ILogSubject"/> using the void logger so the
+    /// classifier can call <c>log.Trace</c> / <c>log.Error</c> without a real logger.
+    /// </summary>
+    private sealed class LogSubject : ILogSubject
+    {
+        /// <summary>Gets the void logger instance.</summary>
+        public ILogger Logger { get; } = VoidLogger.Instance;
+    }
+
+    /// <summary>Log subject passed to <c>ClassifySendException</c> under test.</summary>
+    private readonly ILogSubject _log = new LogSubject();
+
+    /// <summary>
+    /// An <see cref="OperationCanceledException"/> is classified as Canceled.
+    /// </summary>
+    [Fact]
+    public void ClassifySendException_OperationCanceledException_ReturnsCanceled()
+    {
+        var result = Helper.ClassifySendException(new OperationCanceledException(), _log);
+
+        result.Is(SocketSendStatus.Canceled);
+    }
+
+    /// <summary>
+    /// A <see cref="TaskCanceledException"/> (which derives from OCE) is also classified as Canceled.
+    /// </summary>
+    [Fact]
+    public void ClassifySendException_TaskCanceledException_ReturnsCanceled()
+    {
+        var result = Helper.ClassifySendException(new TaskCanceledException(), _log);
+
+        result.Is(SocketSendStatus.Canceled);
+    }
+
+    /// <summary>
+    /// An <see cref="ObjectDisposedException"/> is classified as Closed.
+    /// </summary>
+    [Fact]
+    public void ClassifySendException_ObjectDisposedException_ReturnsClosed()
+    {
+        var result = Helper.ClassifySendException(new ObjectDisposedException("obj"), _log);
+
+        result.Is(SocketSendStatus.Closed);
+    }
+
+    /// <summary>
+    /// An <see cref="InvalidOperationException"/> (that is not ObjectDisposedException) is
+    /// classified as Closed.
+    /// </summary>
+    [Fact]
+    public void ClassifySendException_InvalidOperationException_ReturnsClosed()
+    {
+        var result = Helper.ClassifySendException(new InvalidOperationException("ioe"), _log);
+
+        result.Is(SocketSendStatus.Closed);
+    }
+
+    /// <summary>
+    /// An <see cref="IOException"/> whose <see cref="Exception.InnerException"/> is an
+    /// <see cref="ObjectDisposedException"/> is classified as Closed.
+    /// </summary>
+    [Fact]
+    public void ClassifySendException_IOExceptionWrappingObjectDisposedException_ReturnsClosed()
+    {
+        var inner = new ObjectDisposedException("stream");
+        var outer = new IOException("io", inner);
+
+        var result = Helper.ClassifySendException(outer, _log);
+
+        result.Is(SocketSendStatus.Closed);
+    }
+
+    /// <summary>
+    /// An <see cref="IOException"/> whose <see cref="Exception.InnerException"/> is a
+    /// <see cref="SocketException"/> is classified as Closed.
+    /// </summary>
+    [Fact]
+    public void ClassifySendException_IOExceptionWrappingSocketException_ReturnsClosed()
+    {
+        var inner = new SocketException((int)SocketError.ConnectionReset);
+        var outer = new IOException("io", inner);
+
+        var result = Helper.ClassifySendException(outer, _log);
+
+        result.Is(SocketSendStatus.Closed);
+    }
+
+    /// <summary>
+    /// An unknown / arbitrary exception falls through to the default arm and is classified as Closed.
+    /// </summary>
+    [Fact]
+    public void ClassifySendException_UnknownException_ReturnsClosed()
+    {
+        var result = Helper.ClassifySendException(new Exception("unknown"), _log);
+
+        result.Is(SocketSendStatus.Closed);
+    }
+
+    /// <summary>
+    /// A custom exception type that does not match any of the explicit arms is classified as Closed
+    /// via the default arm.
+    /// </summary>
+    [Fact]
+    public void ClassifySendException_CustomException_ReturnsClosed()
+    {
+        var result = Helper.ClassifySendException(new CustomException("custom"), _log);
+
+        result.Is(SocketSendStatus.Closed);
+    }
+
+    /// <summary>Test-only exception used to exercise the default classification arm.</summary>
+    private sealed class CustomException(string message) : Exception(message);
+}

--- a/base/Net/tests/Annium.Net.Sockets.Tests/Internal/MessagingBufferTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/Internal/MessagingBufferTests.cs
@@ -240,6 +240,61 @@ public class MessagingBufferTests
 }
 
 /// <summary>
+/// Tests for messaging buffer invalid (negative) header detection
+/// </summary>
+public class MessagingBufferNegativeHeaderTests
+{
+    /// <summary>
+    /// Writing a 4-byte header whose int32 value is -1 must set HasInvalidHeader to true.
+    /// Note: ContainsFullMessage may also be true for negative lengths because
+    /// HeaderSize + (negative) can be less than the already-written 4 bytes; the
+    /// receiving loop guards on HasInvalidHeader before inspecting ContainsFullMessage.
+    /// </summary>
+    [Fact]
+    public void NegativeFrameHeader_MinusOne_SetsHasInvalidHeader()
+    {
+        using var buffer = new MessagingBuffer(16, 1024);
+
+        // Write a 4-byte header encoding -1 (negative length)
+        buffer.Write(BitConverter.GetBytes(-1));
+
+        // assert: invalid header is flagged
+        buffer.HasInvalidHeader.IsTrue();
+    }
+
+    /// <summary>
+    /// Writing a 4-byte header whose int32 value is -100 must also set HasInvalidHeader to true.
+    /// </summary>
+    [Fact]
+    public void NegativeFrameHeader_NegativeHundred_SetsHasInvalidHeader()
+    {
+        using var buffer = new MessagingBuffer(16, 1024);
+
+        // Write a 4-byte header encoding -100 (negative length)
+        buffer.Write(BitConverter.GetBytes(-100));
+
+        // assert: invalid header is flagged
+        buffer.HasInvalidHeader.IsTrue();
+    }
+
+    /// <summary>
+    /// After Reset() following an invalid header, HasInvalidHeader is cleared.
+    /// </summary>
+    [Fact]
+    public void NegativeFrameHeader_AfterReset_HasInvalidHeaderIsCleared()
+    {
+        using var buffer = new MessagingBuffer(16, 1024);
+
+        buffer.Write(BitConverter.GetBytes(-1));
+        buffer.HasInvalidHeader.IsTrue();
+
+        // Reset clears invalid-header state
+        buffer.Reset();
+        buffer.HasInvalidHeader.IsFalse();
+    }
+}
+
+/// <summary>
 /// Extension methods for messaging buffer testing
 /// </summary>
 file static class BufferExtensions

--- a/base/Net/tests/Annium.Net.Sockets.Tests/Internal/MessagingManagedSocketListenDisposedTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/Internal/MessagingManagedSocketListenDisposedTests.cs
@@ -1,0 +1,66 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Annium.Logging;
+using Annium.Net.Sockets.Internal;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Net.Sockets.Tests.Internal;
+
+/// <summary>
+/// Tests for the <see cref="MessagingManagedSocket.ListenAsync"/> disposed fast-path:
+/// when the socket is already disposed, <c>ListenAsync</c> must return
+/// <see cref="SocketCloseStatus.ClosedLocal"/> immediately without touching the stream.
+/// </summary>
+public class MessagingManagedSocketListenDisposedTests
+{
+    /// <summary>
+    /// After <see cref="MessagingManagedSocket.Dispose"/> is called, a subsequent
+    /// <see cref="MessagingManagedSocket.ListenAsync"/> must return immediately with
+    /// <see cref="SocketCloseStatus.ClosedLocal"/> and no exception.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task ListenAsync_AfterDispose_ReturnsClosedLocal()
+    {
+        await using var stream = new MemoryStream();
+        var socket = new MessagingManagedSocket(stream, ManagedSocketOptionsBase.Default, VoidLogger.Instance);
+
+        // MessagingManagedSocket implements only IDisposable (no DisposeAsync); suppress
+        // the VSTHRD103 warning that fires because a DisposeAsync extension exists for IDisposable.
+#pragma warning disable VSTHRD103
+        socket.Dispose();
+#pragma warning restore VSTHRD103
+
+        var result = await socket.ListenAsync(CancellationToken.None);
+
+        result.Status.Is(SocketCloseStatus.ClosedLocal);
+        result.Exception.IsDefault();
+    }
+
+    /// <summary>
+    /// After dispose, <c>ListenAsync</c> with a pre-cancelled token must still return
+    /// <see cref="SocketCloseStatus.ClosedLocal"/> (the disposed check precedes the
+    /// cancellation check).
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task ListenAsync_AfterDisposeWithCancelledToken_ReturnsClosedLocal()
+    {
+        await using var stream = new MemoryStream();
+        var socket = new MessagingManagedSocket(stream, ManagedSocketOptionsBase.Default, VoidLogger.Instance);
+
+#pragma warning disable VSTHRD103
+        socket.Dispose();
+#pragma warning restore VSTHRD103
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var result = await socket.ListenAsync(cts.Token);
+
+        result.Status.Is(SocketCloseStatus.ClosedLocal);
+        result.Exception.IsDefault();
+    }
+}

--- a/base/Net/tests/Annium.Net.Sockets.Tests/Internal/MessagingManagedSocketSemaphoreGuardTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/Internal/MessagingManagedSocketSemaphoreGuardTests.cs
@@ -28,8 +28,8 @@ public class MessagingManagedSocketSemaphoreGuardTests
     public async Task SendAsync_PreCancelledToken_DoesNotCorruptSemaphore()
     {
         // arrange — a MemoryStream is enough; we exercise the semaphore path only
-        var stream = new MemoryStream();
-        var socket = new MessagingManagedSocket(stream, ManagedSocketOptionsBase.Default, VoidLogger.Instance);
+        using var stream = new MemoryStream();
+        using var socket = new MessagingManagedSocket(stream, ManagedSocketOptionsBase.Default, VoidLogger.Instance);
 
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();

--- a/base/Net/tests/Annium.Net.Sockets.Tests/Internal/MessagingManagedSocketTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/Internal/MessagingManagedSocketTests.cs
@@ -596,15 +596,6 @@ public class MessagingManagedSocketTests : TestBase
     }
 
     /// <summary>
-    /// Initializes the test asynchronously
-    /// </summary>
-    /// <returns>A task representing the initialization</returns>
-    public override ValueTask InitializeAsync()
-    {
-        return base.InitializeAsync();
-    }
-
-    /// <summary>
     /// Disposes the test resources asynchronously
     /// </summary>
     /// <returns>A task representing the disposal</returns>
@@ -631,12 +622,7 @@ public class MessagingManagedSocketTests : TestBase
         switch (streamType)
         {
             case StreamType.Plain:
-                _createClientStreamAsync = async socket =>
-                {
-                    await Task.CompletedTask;
-
-                    return new NetworkStream(socket);
-                };
+                _createClientStreamAsync = CreatePlainClientStreamAsync;
 
                 _runServer = handleSocket =>
                 {
@@ -664,26 +650,7 @@ public class MessagingManagedSocketTests : TestBase
                 };
                 break;
             case StreamType.Ssl:
-                _createClientStreamAsync = async socket =>
-                {
-                    var networkStream = new NetworkStream(socket);
-                    var sslStream = new SslStream(networkStream, false, ValidateServerCertificate, null);
-
-                    await sslStream.AuthenticateAsClientAsync(string.Empty);
-
-                    return sslStream;
-
-                    bool ValidateServerCertificate(
-                        object sender,
-                        X509Certificate? certificate,
-                        X509Chain? chain,
-                        SslPolicyErrors sslPolicyErrors
-                    )
-                    {
-                        // by design, no ssl verification in tests (cause it will require valid SSL certificate)
-                        return true;
-                    }
-                };
+                _createClientStreamAsync = CreateSslClientStreamAsync;
 
                 _runServer = handleSocket =>
                 {
@@ -765,8 +732,6 @@ public class MessagingManagedSocketTests : TestBase
         );
 
         ManagedSocket.OnReceived += x => _messages.Add(x.ToArray());
-
-        await Task.CompletedTask;
 
         this.Trace("done");
     }

--- a/base/Net/tests/Annium.Net.Sockets.Tests/Internal/RawManagedSocketTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/Internal/RawManagedSocketTests.cs
@@ -476,15 +476,6 @@ public class RawManagedSocketTests : TestBase
     }
 
     /// <summary>
-    /// Initializes the test asynchronously
-    /// </summary>
-    /// <returns>A task representing the initialization</returns>
-    public override ValueTask InitializeAsync()
-    {
-        return base.InitializeAsync();
-    }
-
-    /// <summary>
     /// Disposes the test resources asynchronously
     /// </summary>
     /// <returns>A task representing the disposal</returns>
@@ -510,12 +501,7 @@ public class RawManagedSocketTests : TestBase
         switch (streamType)
         {
             case StreamType.Plain:
-                _createClientStreamAsync = async socket =>
-                {
-                    await Task.CompletedTask;
-
-                    return new NetworkStream(socket);
-                };
+                _createClientStreamAsync = CreatePlainClientStreamAsync;
 
                 _runServer = handleSocket =>
                 {
@@ -543,26 +529,7 @@ public class RawManagedSocketTests : TestBase
                 };
                 break;
             case StreamType.Ssl:
-                _createClientStreamAsync = async socket =>
-                {
-                    var networkStream = new NetworkStream(socket);
-                    var sslStream = new SslStream(networkStream, false, ValidateServerCertificate, null);
-
-                    await sslStream.AuthenticateAsClientAsync(string.Empty);
-
-                    return sslStream;
-
-                    bool ValidateServerCertificate(
-                        object sender,
-                        X509Certificate? certificate,
-                        X509Chain? chain,
-                        SslPolicyErrors sslPolicyErrors
-                    )
-                    {
-                        // by design, no ssl verification in tests (cause it will require valid SSL certificate)
-                        return true;
-                    }
-                };
+                _createClientStreamAsync = CreateSslClientStreamAsync;
 
                 _runServer = handleSocket =>
                 {
@@ -639,8 +606,6 @@ public class RawManagedSocketTests : TestBase
         );
 
         ManagedSocket.OnReceived += x => _stream.AddRange(x.ToArray());
-
-        await Task.CompletedTask;
 
         this.Trace("done");
     }

--- a/base/Net/tests/Annium.Net.Sockets.Tests/Internal/SendingSocketExtensionsTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/Internal/SendingSocketExtensionsTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Annium.Logging;
+using Annium.Net.Sockets.Internal;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Net.Sockets.Tests.Internal;
+
+/// <summary>
+/// Tests for <see cref="Annium.Net.Sockets.SendingSocketExtensions.SendTextAsync"/> over an
+/// in-memory <see cref="MessagingManagedSocket"/>.
+/// </summary>
+public class SendingSocketExtensionsTests
+{
+    /// <summary>
+    /// Sending an ASCII-plus-multibyte-Unicode string returns Ok, and the payload written
+    /// to the underlying MemoryStream decodes (after stripping the 4-byte length-prefix
+    /// framing added by MessagingManagedSocket) to the original UTF-8 bytes.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task SendTextAsync_AsciiAndUnicodeString_WritesUtf8PayloadAndReturnsOk()
+    {
+        // UTF-8: ASCII + 3-byte kanji + 4-byte emoji
+        const string text = "hello 世界 \U0001f600";
+        var expectedBytes = Encoding.UTF8.GetBytes(text);
+
+        using var stream = new MemoryStream();
+        using var socket = new MessagingManagedSocket(stream, ManagedSocketOptionsBase.Default, VoidLogger.Instance);
+
+        var status = await socket.SendTextAsync(text, CancellationToken.None);
+
+        status.Is(SocketSendStatus.Ok);
+
+        // The messaging framing prepends a 4-byte little-endian payload-length header.
+        var written = stream.ToArray();
+        written.Length.Is(sizeof(int) + expectedBytes.Length);
+
+        var framedLength = BitConverter.ToInt32(written, 0);
+        framedLength.Is(expectedBytes.Length);
+
+        var payload = written.AsSpan(sizeof(int)).ToArray();
+        payload.IsEqual(expectedBytes);
+    }
+
+    /// <summary>
+    /// Sending with a pre-cancelled token returns Canceled without writing to the stream.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task SendTextAsync_PreCancelledToken_ReturnsCanceled()
+    {
+        using var stream = new MemoryStream();
+        using var socket = new MessagingManagedSocket(stream, ManagedSocketOptionsBase.Default, VoidLogger.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var status = await socket.SendTextAsync("anything", cts.Token);
+
+        status.Is(SocketSendStatus.Canceled);
+
+        // Nothing should have been written to the stream because the send was short-circuited.
+        stream.Length.Is(0L);
+    }
+
+    /// <summary>
+    /// Round-trip: the bytes received by a second MessagingManagedSocket reading from the same
+    /// MemoryStream decode to the original text.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task SendTextAsync_RoundTrip_ReceivedBytesDecodeToOriginalText()
+    {
+        const string text = "pingé世";
+        var expectedBytes = Encoding.UTF8.GetBytes(text);
+
+        // Write side: sender → MemoryStream
+        using var stream = new MemoryStream();
+        using var sender = new MessagingManagedSocket(stream, ManagedSocketOptionsBase.Default, VoidLogger.Instance);
+        await sender.SendTextAsync(text, CancellationToken.None);
+
+        // Reset to start so the receiver can read the framed data.
+        stream.Position = 0;
+
+        ReadOnlyMemory<byte>? received = null;
+        using var reader = new MessagingManagedSocket(stream, ManagedSocketOptionsBase.Default, VoidLogger.Instance);
+        reader.OnReceived += msg => received = msg;
+
+        // ListenAsync will return once the stream ends (ClosedRemote).
+        await reader.ListenAsync(CancellationToken.None);
+
+        received.IsNotNull();
+        received!.Value.ToArray().IsEqual(expectedBytes);
+    }
+}

--- a/base/Net/tests/Annium.Net.Sockets.Tests/ReceivingSocketExtensionsTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/ReceivingSocketExtensionsTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using Annium.Logging;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Net.Sockets.Tests;
+
+/// <summary>
+/// Tests for <see cref="ReceivingSocketExtensions.Observe"/>.
+/// </summary>
+public class ReceivingSocketExtensionsTests
+{
+    /// <summary>
+    /// Three OnReceived raises produce exactly three items through the observable in order.
+    /// </summary>
+    [Fact]
+    public void Observe_ThreeEvents_EmitsThreeItemsInOrder()
+    {
+        var fake = new FakeReceivingSocket();
+        var items = new List<byte[]>();
+
+        using var sub = fake.Observe().Subscribe(mem => items.Add(mem.ToArray()));
+
+        var a = new byte[] { 1 };
+        var b = new byte[] { 2, 3 };
+        var c = new byte[] { 4, 5, 6 };
+
+        fake.RaiseReceived(a);
+        fake.RaiseReceived(b);
+        fake.RaiseReceived(c);
+
+        items.Has(3);
+        items.At(0).IsEqual(a);
+        items.At(1).IsEqual(b);
+        items.At(2).IsEqual(c);
+    }
+
+    /// <summary>
+    /// After the subscription is disposed, further OnReceived raises do not reach the observer.
+    /// </summary>
+    [Fact]
+    public void Observe_AfterDispose_NoFurtherEmissions()
+    {
+        var fake = new FakeReceivingSocket();
+        var items = new List<byte[]>();
+
+        var sub = fake.Observe().Subscribe(mem => items.Add(mem.ToArray()));
+
+        fake.RaiseReceived(new byte[] { 1 });
+        items.Has(1);
+
+        // Dispose the subscription — the handler must be unsubscribed.
+        sub.Dispose();
+
+        fake.RaiseReceived(new byte[] { 2 });
+
+        // Still only one item; the second raise was ignored.
+        items.Has(1);
+    }
+
+    /// <summary>
+    /// After the subscription is disposed, the underlying OnReceived event has no remaining
+    /// subscribers (the handler added by Observe() was removed).
+    /// </summary>
+    [Fact]
+    public void Observe_AfterDispose_HandlerIsUnsubscribed()
+    {
+        var fake = new FakeReceivingSocket();
+
+        var sub = fake.Observe().Subscribe(_ => { });
+        fake.HasSubscribers.IsTrue();
+
+        sub.Dispose();
+
+        fake.HasSubscribers.IsFalse();
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IReceivingSocket"/> fake with a raisable <see cref="OnReceived"/>
+    /// event and a <see cref="HasSubscribers"/> helper.
+    /// </summary>
+    private sealed class FakeReceivingSocket : IReceivingSocket
+    {
+        private event Action<ReadOnlyMemory<byte>>? _onReceived;
+
+        /// <inheritdoc />
+        public event Action<ReadOnlyMemory<byte>> OnReceived
+        {
+            add { _onReceived += value; }
+            remove { _onReceived -= value; }
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> when at least one handler is subscribed to
+        /// <see cref="OnReceived"/>.
+        /// </summary>
+        public bool HasSubscribers => _onReceived is not null;
+
+        /// <summary>Raises the <see cref="OnReceived"/> event with the given data.</summary>
+        /// <param name="data">Data to deliver to subscribers.</param>
+        public void RaiseReceived(ReadOnlyMemory<byte> data) => _onReceived?.Invoke(data);
+    }
+}

--- a/base/Net/tests/Annium.Net.Sockets.Tests/ServerShutdownOrderingTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/ServerShutdownOrderingTests.cs
@@ -1,9 +1,9 @@
+using System;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Annium.Logging;
-using Annium.Testing;
 using Xunit;
 
 namespace Annium.Net.Sockets.Tests;
@@ -19,20 +19,25 @@ public class ServerShutdownOrderingTests : TestBase
         : base(outputHelper) { }
 
     /// <summary>
-    /// Spawns a server whose handler loops forever while respecting cancellation.
-    /// Connects a client, then disposes the server. Dispose must complete in under 1s
-    /// with the new stop-then-drain ordering.
+    /// Spawns a server whose handler loops forever while respecting cancellation. Connects a
+    /// client, waits for the handler to actually enter its loop, then disposes the server and
+    /// asserts the dispose completes without hanging — the stop-then-drain ordering lets the
+    /// in-flight handler observe cancellation and exit promptly.
     /// </summary>
     /// <returns>A task that represents the asynchronous test.</returns>
     [Fact]
-    public async Task DisposeAsync_WithInfiniteLoopHandler_CompletesInUnderOneSecond()
+    public async Task DisposeAsync_WithInfiniteLoopHandler_CompletesWithoutHanging()
     {
         this.Trace("start");
 
-        // arrange — server with a handler that loops while respecting ct
+        var handlerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // arrange — server with a handler that signals once it enters its ct-respecting loop
         var server = RunServerBase(
             async (_, socket, ct) =>
             {
+                handlerStarted.TrySetResult();
+
                 try
                 {
                     while (!ct.IsCancellationRequested)
@@ -51,17 +56,17 @@ public class ServerShutdownOrderingTests : TestBase
         using var client = new TcpClient();
         await client.ConnectAsync(IPAddress.Loopback, server.Port, TestContext.Current.CancellationToken);
 
-        // give the handler a moment to start its loop
-        await Task.Delay(100, TestContext.Current.CancellationToken);
+        // wait for the handler to actually enter its loop (replaces a fixed Task.Delay start race)
+        await handlerStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        // act — dispose and time it
+        // act + assert — dispose must complete and NOT hang. A bounded wait fails fast on a
+        // regression (wrong ordering → drain blocks on the in-flight handler) while tolerating CI
+        // scheduling jitter, unlike a tight wall-clock comparison.
         var sw = Stopwatch.StartNew();
-        await server.DisposeAsync();
+        await server.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         sw.Stop();
 
-        // assert — with stop-then-drain ordering, dispose completes well under 1s
         this.Trace<long>("dispose took {ms}ms", sw.ElapsedMilliseconds);
-        sw.ElapsedMilliseconds.IsLess(1000);
 
         this.Trace("done");
     }

--- a/base/Net/tests/Annium.Net.Sockets.Tests/ServerSocketDisposeTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/ServerSocketDisposeTests.cs
@@ -1,0 +1,61 @@
+using System.IO;
+using Annium.Logging;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Net.Sockets.Tests;
+
+/// <summary>
+/// Tests that <see cref="ServerSocket.Dispose"/> is safe in isolation-dispose scenarios.
+/// <para>
+/// <see cref="ServerSocketOptions.Default"/> uses no connection-monitor factory, so
+/// <see cref="Annium.Net.Sockets.Internal.NoneConnectionMonitor"/> is installed — its
+/// <c>Stop()</c> is a no-op, making it safe to dispose without driving a full connection lifecycle.
+/// </para>
+/// <para>
+/// Unlike <see cref="ClientSocket.Dispose"/> (which calls <c>Disconnect()</c> internally),
+/// <see cref="ServerSocket.Dispose"/> performs a forced-close without updating
+/// <see cref="ServerSocket.IsConnected"/> synchronously. The correct graceful shutdown
+/// sequence is <c>Disconnect()</c> followed by <c>Dispose()</c>.
+/// </para>
+/// </summary>
+public class ServerSocketDisposeTests
+{
+    /// <summary>
+    /// After <see cref="ServerSocket.Disconnect"/> + <see cref="ServerSocket.Dispose"/>,
+    /// the socket reports <c>IsConnected == false</c>. <c>Disconnect()</c> transitions
+    /// the status synchronously; <c>Dispose()</c> must not throw.
+    /// </summary>
+    [Fact]
+    public void Dispose_AfterDisconnect_DoesNotThrowAndIsDisconnected()
+    {
+        using var stream = new MemoryStream();
+        var socket = new ServerSocket(stream, ServerSocketOptions.Default, VoidLogger.Instance);
+
+        socket.Disconnect();
+        socket.Dispose();
+
+        socket.IsConnected.IsFalse();
+    }
+
+    /// <summary>
+    /// Calling <see cref="ServerSocket.Dispose"/> a second time must not throw.
+    /// After the first forced-close <c>Dispose()</c> the monitor is already stopped and the
+    /// managed socket already disposed; the second call is a no-op on both.
+    /// </summary>
+    [Fact]
+    public void Dispose_CalledTwice_DoesNotThrow()
+    {
+        using var stream = new MemoryStream();
+        var socket = new ServerSocket(stream, ServerSocketOptions.Default, VoidLogger.Instance);
+
+        socket.Dispose();
+        socket.Dispose();
+
+        // If neither Dispose() call threw, the test passes. The IsConnected state is
+        // not asserted here because Dispose() without a prior Disconnect() does not
+        // synchronously transition the status — that happens on the background IsClosed
+        // continuation. The no-throw behaviour is the correctness property under test.
+        socket.IsConnected.Is(socket.IsConnected); // readable without throw
+    }
+}

--- a/base/Net/tests/Annium.Net.Sockets.Tests/ServerSocketExtensionsTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/ServerSocketExtensionsTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Annium.Logging;
+using Annium.Testing;
+using Xunit;
+
+namespace Annium.Net.Sockets.Tests;
+
+/// <summary>
+/// Tests for <see cref="ServerSocketExtensions"/>.
+/// </summary>
+public class ServerSocketExtensionsTests
+{
+    // -------------------------------------------------------------------------
+    // WhenDisconnectedAsync cancellation — TG11 (server variant)
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// When the cancellation token is cancelled before OnDisconnected fires,
+    /// <see cref="ServerSocketExtensions.WhenDisconnectedAsync"/> throws
+    /// <see cref="OperationCanceledException"/> and the handler is unsubscribed.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task WhenDisconnectedAsync_TokenCancelledBeforeDisconnected_ThrowsAndUnsubscribes()
+    {
+        var fake = new FakeServerSocket();
+        using var cts = new CancellationTokenSource();
+
+        var waitTask = fake.WhenDisconnectedAsync(cts.Token);
+
+        // Cancel the token before OnDisconnected is ever raised.
+        await cts.CancelAsync();
+
+        // waitTask was started before the cancel (exercises cancel-after-subscribe),
+        // so it is awaited directly here — manual try/catch to avoid VSTHRD003.
+        var threw = false;
+        try
+        {
+            await waitTask;
+        }
+        catch (OperationCanceledException)
+        {
+            threw = true;
+        }
+
+        threw.IsTrue();
+
+        // After cancellation the OnDisconnected handler should be unsubscribed.
+        fake.HasDisconnectedSubscribers.IsFalse();
+    }
+
+    /// <summary>
+    /// When the cancellation token is already cancelled at call time,
+    /// <see cref="ServerSocketExtensions.WhenDisconnectedAsync"/> throws immediately
+    /// without leaking the subscription.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task WhenDisconnectedAsync_PreCancelledToken_ThrowsImmediatelyAndUnsubscribes()
+    {
+        var fake = new FakeServerSocket();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Wrap.It(async () => await fake.WhenDisconnectedAsync(cts.Token))
+            .ThrowsAsync<OperationCanceledException>();
+        fake.HasDisconnectedSubscribers.IsFalse();
+    }
+
+    /// <summary>
+    /// After cancellation, raising OnDisconnected on the fake has no effect — the subscription
+    /// was cleaned up and no dangling handler remains.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Fact]
+    public async Task WhenDisconnectedAsync_AfterCancellation_RaisingDisconnectedHasNoEffect()
+    {
+        var fake = new FakeServerSocket();
+        using var cts = new CancellationTokenSource();
+
+        var waitTask = fake.WhenDisconnectedAsync(cts.Token);
+        await cts.CancelAsync();
+
+        try
+        {
+            await waitTask;
+        }
+        catch (OperationCanceledException)
+        {
+            // expected
+        }
+
+        // Raise disconnected — must not throw and the subscriber count stays at zero.
+        fake.RaiseDisconnected(SocketCloseStatus.ClosedRemote);
+        fake.HasDisconnectedSubscribers.IsFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Fake
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Minimal <see cref="IServerSocket"/> fake with a raisable <see cref="OnDisconnected"/> event
+    /// and a subscriber-count helper for TG11.
+    /// </summary>
+    private sealed class FakeServerSocket : IServerSocket
+    {
+        /// <summary>Gets the logger used by this fake.</summary>
+        public ILogger Logger { get; } = VoidLogger.Instance;
+
+        /// <summary>Always false — this fake is never actually connected.</summary>
+        public bool IsConnected => false;
+
+        private event Action<SocketCloseStatus>? _onDisconnected;
+
+        /// <summary>Raised when the socket disconnects; routes through the backing field so subscriber count is observable.</summary>
+        public event Action<SocketCloseStatus> OnDisconnected
+        {
+            add => _onDisconnected += value;
+            remove => _onDisconnected -= value;
+        }
+
+        public event Action<Exception>? OnError
+        {
+            add { }
+            remove { }
+        }
+
+        public event Action<ReadOnlyMemory<byte>>? OnReceived
+        {
+            add { }
+            remove { }
+        }
+
+        /// <summary>
+        /// <see langword="true"/> when at least one handler is subscribed to <see cref="OnDisconnected"/>.
+        /// </summary>
+        public bool HasDisconnectedSubscribers => _onDisconnected is not null;
+
+        /// <summary>Raises the <c>OnDisconnected</c> event with the given close status.</summary>
+        /// <param name="status">The close status to pass to subscribers.</param>
+        public void RaiseDisconnected(SocketCloseStatus status) => _onDisconnected?.Invoke(status);
+
+        /// <summary>Not implemented — this fake only exercises the event subscription path.</summary>
+        public void Disconnect() => throw new NotImplementedException();
+
+        /// <summary>Not implemented — this fake only exercises the event subscription path.</summary>
+        /// <param name="data">The data to send.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>A <c>ValueTask&lt;SocketSendStatus&gt;</c> representing the pending send.</returns>
+        public ValueTask<SocketSendStatus> SendAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        /// <summary>Disposes the fake socket (no-op).</summary>
+        public void Dispose() { }
+    }
+}

--- a/base/Net/tests/Annium.Net.Sockets.Tests/TestBase.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/TestBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Security;
 using System.Net.Sockets;
@@ -20,7 +21,9 @@ public abstract class TestBase : Testing.TestBase
     /// <summary>
     /// Random number generator for test data
     /// </summary>
-    private readonly Random _random = new();
+    // seeded so generated message sizes/contents are deterministic and reproducible across runs
+    // (a failure on a particular size can be re-run; a fresh TestBase per test gives each its own sequence).
+    private readonly Random _random = new(12345);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TestBase"/> class
@@ -63,6 +66,47 @@ public abstract class TestBase : Testing.TestBase
             checkCertificateRevocation: true
         );
         return sslStream;
+    }
+
+    /// <summary>
+    /// Creates a plain (non-SSL) client-side stream over the connected socket. The returned
+    /// <see cref="NetworkStream"/> owns the socket (<c>ownsSocket: true</c>) so disposing the stream
+    /// in test teardown closes the socket.
+    /// </summary>
+    /// <param name="socket">The connected client socket.</param>
+    /// <returns>A plain client stream owning <paramref name="socket"/>.</returns>
+    protected static Task<Stream> CreatePlainClientStreamAsync(Socket socket)
+    {
+        return Task.FromResult<Stream>(new NetworkStream(socket, ownsSocket: true));
+    }
+
+    /// <summary>
+    /// Creates an authenticated SSL client-side stream over the connected socket. The inner
+    /// <see cref="NetworkStream"/> owns the socket (<c>ownsSocket: true</c>) and the
+    /// <see cref="SslStream"/> owns the inner stream, so disposing the returned stream in test
+    /// teardown closes the socket. Server certificate validation is disabled (tests use a self-signed cert).
+    /// </summary>
+    /// <param name="socket">The connected client socket.</param>
+    /// <returns>An authenticated SSL client stream owning <paramref name="socket"/>.</returns>
+    protected static async Task<Stream> CreateSslClientStreamAsync(Socket socket)
+    {
+        var networkStream = new NetworkStream(socket, ownsSocket: true);
+        var sslStream = new SslStream(networkStream, false, ValidateServerCertificate, null);
+
+        await sslStream.AuthenticateAsClientAsync(string.Empty);
+
+        return sslStream;
+
+        static bool ValidateServerCertificate(
+            object sender,
+            X509Certificate? certificate,
+            X509Chain? chain,
+            SslPolicyErrors sslPolicyErrors
+        )
+        {
+            // by design, no ssl verification in tests (cause it will require valid SSL certificate)
+            return true;
+        }
     }
 
     /// <summary>

--- a/base/Net/tests/Annium.Net.Sockets.Tests/WhenDisconnectedAsyncTests.cs
+++ b/base/Net/tests/Annium.Net.Sockets.Tests/WhenDisconnectedAsyncTests.cs
@@ -132,6 +132,9 @@ public class WhenDisconnectedAsyncTests
         /// <summary>Gets the logger associated with this server socket.</summary>
         public ILogger Logger { get; } = VoidLogger.Instance;
 
+        /// <summary>Always reports connected — this fake only exercises the event subscription path.</summary>
+        public bool IsConnected => true;
+
         public event Action<SocketCloseStatus>? OnDisconnected;
         public event Action<Exception>? OnError
         {


### PR DESCRIPTION
Annium.Net.Sockets review pass. Fix lifecycle/disposal leaks (terminal _connectionCts and never-connected _listenCts; nativeSocket on failed connect), a dropped reconnect cancellation token, the WhenConnected/ WaitForDisconnect handler leak on cancellation, the connect/disconnect ObjectDisposedException races, and ConnectAsync returning the success sentinel (null) on cancellation instead of OperationCanceledException.

Extract IConnectionMonitor (IConnectionMonitorFactory.Create now returns it); add IServerSocket.IsConnected; unify ConnectionMonitorOptions durations to int; create event TaskCompletionSources with RunContinuationsAsynchronously.

Add 39 tests (91 -> 130) covering the above plus framing, disposal, idempotency and cancellation paths; de-flake Listen_ConnectionLost, Listen_Reconnect and the server-shutdown timing test; document new public surface to keep docs-lint green.